### PR TITLE
Update config.ini to add path to tshark on OS X

### DIFF
--- a/src/pyshark/config.ini
+++ b/src/pyshark/config.ini
@@ -1,3 +1,3 @@
 [tshark]
 windows_paths = C:\Program Files\Wireshark\tshark.exe,C:\Program Files (x86)\Wireshark\tshark.exe
-linux_paths = /usr/lib/tshark
+linux_paths = /usr/lib/tshark,/usr/local/bin/tshark


### PR DESCRIPTION
Hi,

tshark is installed on /usr/local/bin/tshark on OS X 10.9 (Mavericks)
