### PR TITLE
Fixed packet timestamp code by using 'raw' instead of 'show' value

### DIFF
--- a/src/pyshark/packet/packet.py
+++ b/src/pyshark/packet/packet.py
@@ -61,7 +61,7 @@ class Packet(object):
 
     @property
     def sniff_time(self):
-        return datetime.datetime.fromtimestamp(self.sniff_timestamp)
+        return datetime.datetime.fromtimestamp(float(self.sniff_timestamp))
 
     def __repr__(self):
         transport_protocol = ''

--- a/src/pyshark/tshark/tshark_xml.py
+++ b/src/pyshark/tshark/tshark_xml.py
@@ -18,7 +18,7 @@ def packet_from_xml_packet(xml_pkt):
     layers = [Layer(proto) for proto in xml_pkt.proto]
     geninfo, frame, layers = layers[0], layers[1], layers[2:]
     frame.raw_mode = True
-    return Packet(layers=layers, length=geninfo.get_field_value('len'), sniff_time=geninfo.get_field_value('timestamp'),
+    return Packet(layers=layers, length=geninfo.get_field_value('len'), sniff_time=geninfo.get_field_value('timestamp', raw=True),
                   captured_length=geninfo.get_field_value('caplen'), interface_captured=frame.get_field_value('interface_id'))
 
 


### PR DESCRIPTION
sniff_time() expects a float in sniff_timestamp, but sniff_timestamp was using the 'show' value from the tshark XML output, which contains an interpreted datetime string. Fixed this by getting the value for sniff_timestamp from the 'raw' field, which contains the timestamp as a float in string format. This is converted to float in-place in sniff_time()
