### PR TITLE
Changed behavior so packets are not stored in memory for lazy packet iteration

### DIFF
--- a/src/pyshark/capture/file_capture.py
+++ b/src/pyshark/capture/file_capture.py
@@ -37,7 +37,12 @@ class FileCapture(Capture):
     def next(self):
         if self._packet_generator and self.current_packet >= len(self._packets):
             packet = self._packet_generator.next()
-            self._packets += [packet]
+            if not self.lazy:
+                self._packets += [packet]
+            else:
+                # If we're in lazy mode we'd like to conserve memory and not save all seen packets,
+                # but simply iterate one-by-one
+                return packet
         return super(FileCapture, self).next()
 
     def __getitem__(self, packet_index):

--- a/src/pyshark/packet/packet.py
+++ b/src/pyshark/packet/packet.py
@@ -17,7 +17,7 @@ class Packet(object):
         :param layers: A list of Layer objects.
         :param length: Length of the actual packet.
         :param captured_length: The length of the packet that was actually captured (could be less then length)
-        :param sniff_time: The time the packet was captured (timestamp)
+        :param sniff_time: The time the packet was captured (string timestamp in epoch time format)
         :param interface_captured: The interface the packet was captured in.
         """
         if layers is None:


### PR DESCRIPTION
With the "lazy" parameter enabled, the packets that are being read are
not stored in memory any longer. (This proves to consume a lot of memory usage
for big cap files)

Perhaps further refactoring (perhaps "LazyCapture" class) should be
implemented. In the interim - I patched the code so packets are not stored if "lazy" is enabled.
