### PR TITLE
Workaround for invalid timestamps that might occur in capture files.

### DIFF
--- a/src/pyshark/packet/packet.py
+++ b/src/pyshark/packet/packet.py
@@ -61,7 +61,13 @@ class Packet(object):
 
     @property
     def sniff_time(self):
-        return datetime.datetime.fromtimestamp(float(self.sniff_timestamp))
+        try:
+            timestamp = float(self.sniff_timestamp)
+        except ValueError:
+            # If the value after the decimal point is negative, discard it
+            # Google: wireshark fractional second
+            timestamp = float(self.sniff_timestamp.split(".")[0])
+        return datetime.datetime.fromtimestamp(timestamp)
 
     def __repr__(self):
         transport_protocol = ''


### PR DESCRIPTION
Encountered a problem with some capture files (generated by Wireshark): float(self.sniff_timestamp) would throw an exception on timestamp values such as "1386694288.-00019000". Apparently these values do occur in capture files; Wireshark gives a warning about the timestamp being malformed, but keeps processing the packet anyway. My workaround discards the negative value after the decimal point. Google for "wireshark fractional second" for more occurences.
