### PR TITLE
Re-work the TShark finder

### DIFF
--- a/src/pyshark/config.ini
+++ b/src/pyshark/config.ini
@@ -1,3 +1,9 @@
 [tshark]
-windows_paths = C:\Program Files\Wireshark\tshark.exe,C:\Program Files (x86)\Wireshark\tshark.exe
-linux_paths = /usr/bin/tshark,/usr/lib/tshark,/usr/local/bin/tshark
+# Specify the path to the tshark executable.
+# If the configured path does not exist, these locations will be searched:
+# (Linux): /usr/bin/tshark
+# (Linux): /usr/lib/tshark
+# (Linux): /usr/local/bin/tshark
+# (Windows): %ProgramFiles%\Wireshark\tshark.exe
+# (Windows): %ProgramFiles(x86)%\Wireshark\tshark.exe
+tshark_path = C:\Program Files\Wireshark\tshark.exe

--- a/src/pyshark/tshark/tshark.py
+++ b/src/pyshark/tshark/tshark.py
@@ -13,16 +13,27 @@ class TSharkNotFoundException(Exception):
 
 def get_tshark_path():
     """
-    Finds the path of the tshark executable according to the list in the configuration.
+    Finds the path of the tshark executable. If the user has specified a
+    location in config.ini it will be used. Otherwise default locations
+    will be searched.
 
     :raises TSharkNotFoundException in case TShark is not found in any location.
     """
     config = get_config()
-    if sys.platform.startswith('win'):
-        possible_paths = config.get('tshark', 'windows_paths').split(',')
-    else:
-        possible_paths = config.get('tshark', 'linux_paths').split(',')
 
+    if sys.platform.startswith('win'):
+        win32_progs = os.environ['ProgramFiles(x86)']
+        win64_progs = os.environ['ProgramFiles']
+        tshark_path = ('Wireshark', 'tshark.exe')
+        possible_paths = [config.get('tshark', 'tshark_path'),
+                          os.path.join(win32_progs, *tshark_path),
+                          os.path.join(win64_progs, *tshark_path)]
+    else:
+        possible_paths = [config.get('tshark', 'tshark_path'),
+                          '/usr/bin/tshark',
+                          '/usr/lib/tshark',
+                          '/usr/local/bin/tshark']
+    
     for path in possible_paths:
         if os.path.exists(path):
             return path

--- a/src/setup.py
+++ b/src/setup.py
@@ -7,9 +7,8 @@ setup(
     name = "pyshark",
     version = "0.2.2",
     packages = find_packages(),
-
+    package_data={'': ['*.ini']},
     install_requires = ['lxml', 'py'],
-
     url = "https://github.com/KimiNewt/pyshark",
     long_description=long_description,
     author = "KimiNewt",


### PR DESCRIPTION
Proposing a change to the behavior of the TShark finding mechanism.

**Old way**: User is expected to supply some paths to search for TShark in `config.ini`. Some sensible defaults are provided in that file.

**Proposed way**: User is expected to supply _the_ path for TShark in `config.ini`. If they don't then some sensible defaults are searched.

This fixes a few potential issues:
(1) The current default `config.ini` assumes Windows is installed under `C:`
(2) The current configuration parser doesn't allow for paths with commas
(3) `setup.py` misses `config.ini` (this is [issue 18](https://github.com/KimiNewt/pyshark/issues/18))

(1) and (2) are admittedly uncommon, but (3) is probably a legitimate bug to fix. If you'd rather keep the current behavior I can submit a separate patch for (3) only.

I tested (on Windows) 32-bit Python 2.7 with 64-bit Wireshark and 64-bit Python 3.4 with 64-bit Wireshark. On Linux the default search behavior should be unchanged.
