### PR TITLE
Fix broken test_icmp due to locale

### DIFF
--- a/src/pyshark/test/validate.py
+++ b/src/pyshark/test/validate.py
@@ -44,7 +44,10 @@ class TestFileCaptures(unittest.TestCase):
         """Test to make sure ICMP fields are being read properly by comparing
            packet dissection results to known values"""
         packet = self.cap[11]
-        resptime = packet.icmp.resptime
+        # The value returned by tshark is locale-dependent.
+        # Depending on the locale, a comma can be used instead of a dot
+        # as decimal separator.
+        resptime = packet.icmp.resptime.replace(',', '.')
         self.assertEqual(resptime, '1.667')
 
 if __name__ == '__main__':


### PR DESCRIPTION
The float returned by tshark is locale-dependent.
Depending on the locale, a comma can be used instead of a dot as decimal
separator.

Test was failing on my machine due to the locale (fr_FR.UTF-8):
FAIL: test_icmp (**main**.TestFileCaptures)
Test to make sure ICMP fields are being read properly by comparing
Traceback (most recent call last):
  File "pyshark/test/validate.py", line 48, in test_icmp
    self.assertEqual(resptime, '1.667')
AssertionError: '1,667' != '1.667'
