### PR TITLE
Minor file_capture fixes

### DIFF
--- a/src/pyshark/capture/file_capture.py
+++ b/src/pyshark/capture/file_capture.py
@@ -67,8 +67,8 @@ class FileCapture(Capture):
         """
         Gets an xml file data and returns the packets.
         """
-        beginning = cap_or_xml.read(5)
-        if beginning == b'<?xml':
+        beginning = cap_or_xml.read(20)
+        if b'<?xml' in beginning:
             # It's an xml file.
             return self._packets_from_fd(cap_or_xml, previous_data=beginning, wait_for_more_data=False)
         else:


### PR DESCRIPTION
Here are two small fixes for minor issues with `file_capture.py`.

First - the docstring for `packets_from_file` is outdated; it doesn't return a tuple.

Second - XML detection fails for files with certain encodings, particularly those with a byte order mark (I can attach an example, but basically [the XML spec](http://www.w3.org/TR/xml/#sec-guessing) describes a slightly better way to do the detection for common encodings).
