### PR TITLE
Fix issue #34

### DIFF
--- a/src/pyshark/tshark/tshark.py
+++ b/src/pyshark/tshark/tshark.py
@@ -23,8 +23,8 @@ def get_tshark_path():
     config = get_config()
 
     if sys.platform.startswith('win'):
-        win32_progs = os.environ['ProgramFiles(x86)']
-        win64_progs = os.environ['ProgramFiles']
+        win32_progs = os.environ.get('ProgramFiles(x86)', '')
+        win64_progs = os.environ.get('ProgramFiles', '')
         tshark_path = ('Wireshark', 'tshark.exe')
         possible_paths = [config.get('tshark', 'tshark_path'),
                           os.path.join(win32_progs, *tshark_path),


### PR DESCRIPTION
Issue #34 points out that Windows 32-bit will throw a `KeyError` exception when trying to do `os.environ['ProgramFiles(x86)']`.

This patch changes the behavior so that if that environment variable is missing an empty string will be returned.

The empty string will be ignored in the `os.path.exists()` check later in `tshark.py`.
