### PR TITLE
Add version-dependent display filter flag

### DIFF
--- a/src/pyshark/capture/capture.py
+++ b/src/pyshark/capture/capture.py
@@ -1,3 +1,4 @@
+from distutils.version import LooseVersion
 import os
 import subprocess
 import sys
@@ -20,7 +21,6 @@ class Capture(object):
         self.display_filter = display_filter
         self.only_summaries = only_summaries
         self.tshark_process = None
-        self.tshark_version = get_tshark_version()
 
     def __getitem__(self, item):
         """
@@ -146,7 +146,11 @@ class Capture(object):
         """
         Returns the special tshark parameters to be used according to the configuration of this class.
         """
-        display_filter_flag = '-Y' if self.tshark_version >= (1, 10, 0) else '-R'
+        tshark_version = get_tshark_version()
+        if LooseVersion(tshark_version) >= LooseVersion("1.10.0"):
+            display_filter_flag = '-Y'
+        else:
+            display_filter_flag = '-R'
 
         params = []
         if self.display_filter:

--- a/src/pyshark/tshark/tshark.py
+++ b/src/pyshark/tshark/tshark.py
@@ -46,9 +46,8 @@ def get_tshark_version():
     version_output = subprocess.check_output(parameters).decode("ascii")
     version_line = version_output.splitlines()[0]
     version_string = version_line.split()[1]
-    version_tuple = tuple(int(x) for x in version_string.split('.'))
 
-    return version_tuple
+    return version_string
 
 def get_tshark_interfaces():
     parameters = [get_tshark_path(), '-D']


### PR DESCRIPTION
#38 refers to a problem with using display filters. This patch asks TShark for its version, then chooses a display filter flag that's appropriate for that version.

Consider this script:

``` python
from __future__ import print_function
import pyshark

tshark_version = pyshark.tshark.tshark.get_tshark_version()
print(tshark_version)

parameters = pyshark.capture.capture.Capture(display_filter='something').get_parameters()
print(parameters)
```

When my config.ini points to version 1.6.7, I get output:

```
(1, 6, 7)
['-R', 'something']
```

When it points to version 1.10.6, I get output:

```
(1, 10, 6)
['-Y', 'something']
```
