### PR TITLE
fix parsing of interface list

### DIFF
--- a/src/pyshark/tshark/tshark.py
+++ b/src/pyshark/tshark/tshark.py
@@ -53,4 +53,4 @@ def get_tshark_interfaces():
     parameters = [get_tshark_path(), '-D']
     tshark_interfaces = subprocess.check_output(parameters).decode("ascii")
     
-    return [line.split('.')[0] for line in tshark_interfaces.splitlines()]
+    return [line.split('.')[1] for line in tshark_interfaces.splitlines()]


### PR DESCRIPTION
I checked tshark version 1.6 and it outputs the interface list in the same way (`"1. name\n2. name"...`), so I think this is the simple fix to https://github.com/KimiNewt/pyshark/issues/54