### PR TITLE
TShark module improvements

### DIFF
--- a/src/pyshark/capture/capture.py
+++ b/src/pyshark/capture/capture.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals
-from distutils.version import LooseVersion
 import os
 import logbook
 import sys
@@ -9,7 +8,7 @@ from trollius import From, subprocess, Return
 from trollius.executor import TimeoutError
 from trollius.py33_exceptions import ProcessLookupError
 
-from pyshark.tshark.tshark import get_tshark_path, get_tshark_version
+from pyshark.tshark.tshark import get_tshark_path, get_tshark_display_filter_flag
 from pyshark.tshark.tshark_xml import packet_from_xml_packet, psml_structure_from_xml
 
 
@@ -323,15 +322,9 @@ class Capture(object):
         """
         Returns the special tshark parameters to be used according to the configuration of this class.
         """
-        tshark_version = get_tshark_version()
-        if LooseVersion(tshark_version) >= LooseVersion("1.10.0"):
-            display_filter_flag = '-Y'
-        else:
-            display_filter_flag = '-R'
-
         params = []
         if self.display_filter:
-            params += [display_filter_flag, self.display_filter]
+            params += [get_tshark_display_filter_flag(), self.display_filter]
         if packet_count:
             params += ['-c', str(packet_count)]
         if all(self.encryption):

--- a/src/pyshark/tshark/tshark.py
+++ b/src/pyshark/tshark/tshark.py
@@ -1,6 +1,7 @@
 """
 Module used for the actual running of TShark
 """
+from distutils.version import LooseVersion
 import os
 import subprocess
 import sys
@@ -49,7 +50,21 @@ def get_tshark_version():
 
     return version_string
 
+def get_tshark_display_filter_flag():
+    """
+    Returns '-Y' for tshark versions >= 1.10.0 and '-R' for older versions.
+    """
+    tshark_version = get_tshark_version()
+    if LooseVersion(tshark_version) >= LooseVersion("1.10.0"):
+        return '-Y'
+    else:
+        return '-R'
+
 def get_tshark_interfaces():
+    """
+    Returns a list of interface numbers from the output tshark -D. Used
+    internally to capture on multiple interfaces.
+    """
     parameters = [get_tshark_path(), '-D']
     tshark_interfaces = subprocess.check_output(parameters).decode("ascii")
     

--- a/src/setup.py
+++ b/src/setup.py
@@ -10,6 +10,7 @@ setup(
     packages=find_packages(),
     package_data={'': ['*.ini', '*.pcapng']},
     install_requires=['lxml', 'py', 'trollius', 'logbook'],
+    tests_require=['mock', 'pytest'],
     url="https://github.com/KimiNewt/pyshark",
     long_description=long_description,
     author="KimiNewt",

--- a/tests/test_packet_operations.py
+++ b/tests/test_packet_operations.py
@@ -34,5 +34,7 @@ def test_raw_mode(icmp_packet):
 
 
 def test_frame_info_access(icmp_packet):
-    assert icmp_packet.frame_info.protocols == 'eth:ip:icmp:data'
-    assert icmp_packet.frame_info.number == '8'
+		actual = icmp_packet.frame_info.protocols
+		expected = {'eth:ip:icmp:data', 'eth:ethertype:ip:icmp:data'}
+		assert actual in expected
+		assert icmp_packet.frame_info.number == '8'

--- a/tests/test_tshark.py
+++ b/tests/test_tshark.py
@@ -1,0 +1,39 @@
+import mock
+
+from pyshark.tshark.tshark import (
+    get_tshark_display_filter_flag,
+    get_tshark_interfaces,
+    get_tshark_version,
+)
+
+@mock.patch('pyshark.tshark.tshark.subprocess.check_output', autospec=True)
+def test_get_tshark_version(mock_check_output):
+    mock_check_output.return_value = (
+        b'TShark 1.12.1 (Git Rev Unknown from unknown)\n\n'b'Copyright '
+        b'1998-2014 Gerald Combs <gerald@wireshark.org> and contributors.\n'
+    )
+    actual = get_tshark_version()
+    expected = '1.12.1'
+    assert actual == expected
+
+@mock.patch('pyshark.tshark.tshark.get_tshark_version', autospec=True)
+def test_get_display_filter_flag(mock_get_tshark_version):
+    mock_get_tshark_version.return_value = '1.10.0'
+    actual = get_tshark_display_filter_flag()
+    expected = '-Y'
+    assert actual == expected
+
+    mock_get_tshark_version.return_value = '1.6.0'
+    actual = get_tshark_display_filter_flag()
+    expected = '-R'
+    assert actual == expected
+
+@mock.patch('pyshark.tshark.tshark.subprocess.check_output', autospec=True)
+def test_get_tshark_interfaces(mock_check_output):
+    mock_check_output.return_value = (
+        b'1. wlan0\n2. any\n3. lo (Loopback)\n4. eth0\n5. docker0\n'
+    )
+    actual = get_tshark_interfaces()
+    expected = ['1', '2', '3', '4', '5']
+    assert actual == expected
+


### PR DESCRIPTION
This PR:
* Moves the display filter determination into its own function
* Adds tests for the `tshark` sub-module's functions
* Adds requirements for `mock` and `pytest` to `setup.py`

__Edited to add__:
* Fixes a test failure
* Fixes #53 (thanks @goretkin and @baszoetekouw)
