### PR TITLE
Added optional path parameter to Capture interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ very little information
 * **param decryption_key**: Key used to encrypt and decrypt captured traffic.
 * **param encryption_type**: Standard of encryption used in captured traffic (must
 be either 'WEP', 'WPA-PWD', or 'WPA-PWK'. Defaults to WPA-PWK.
+* **param tshark_path: Path of the tshark binary
 
 ###Reading from a live interface:
 
@@ -82,6 +83,7 @@ includes very little information
 * **param decryption_key**: Key used to encrypt and decrypt captured traffic.
 * **param encryption_type**: Standard of encryption used in captured traffic
 (must be either 'WEP', 'WPA-PWD', or 'WPA-PWK'. Defaults to WPA-PWK).
+* **param tshark_path: Path of the tshark binary
 
 ###Reading from a live remote interface:
 
@@ -106,6 +108,7 @@ includes very little information
 * **param decryption_key**: Key used to encrypt and decrypt captured traffic.
 * **param encryption_type**: Standard of encryption used in captured traffic
 (must be either 'WEP', 'WPA-PWD', or 'WPA-PWK'. Defaults to WPA-PWK).
+* **param tshark_path: Path of the tshark binary
 
 ###Accessing packet data:
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ very little information
 * **param decryption_key**: Key used to encrypt and decrypt captured traffic.
 * **param encryption_type**: Standard of encryption used in captured traffic (must
 be either 'WEP', 'WPA-PWD', or 'WPA-PWK'. Defaults to WPA-PWK.
-* **param tshark_path: Path of the tshark binary
+* **param tshark_path**: Path of the tshark binary
 
 ###Reading from a live interface:
 
@@ -83,7 +83,7 @@ includes very little information
 * **param decryption_key**: Key used to encrypt and decrypt captured traffic.
 * **param encryption_type**: Standard of encryption used in captured traffic
 (must be either 'WEP', 'WPA-PWD', or 'WPA-PWK'. Defaults to WPA-PWK).
-* **param tshark_path: Path of the tshark binary
+* **param tshark_path**: Path of the tshark binary
 
 ###Reading from a live remote interface:
 
@@ -108,7 +108,7 @@ includes very little information
 * **param decryption_key**: Key used to encrypt and decrypt captured traffic.
 * **param encryption_type**: Standard of encryption used in captured traffic
 (must be either 'WEP', 'WPA-PWD', or 'WPA-PWK'. Defaults to WPA-PWK).
-* **param tshark_path: Path of the tshark binary
+* **param tshark_path**: Path of the tshark binary
 
 ###Accessing packet data:
 

--- a/src/pyshark/capture/capture.py
+++ b/src/pyshark/capture/capture.py
@@ -30,7 +30,7 @@ class Capture(object):
     SUPPORTED_ENCRYPTION_STANDARDS = ['wep', 'wpa-pwk', 'wpa-psk']
 
     def __init__(self, display_filter=None, only_summaries=False, eventloop=None,
-                 decryption_key=None, encryption_type='wpa-pwd'):
+                 decryption_key=None, encryption_type='wpa-pwd', tshark_path=None):
         self._packets = []
         self.current_packet = 0
         self.display_filter = display_filter
@@ -38,6 +38,7 @@ class Capture(object):
         self.running_processes = set()
         self.loaded = False
         self.log = logbook.Logger(self.__class__.__name__, level=self.DEFAULT_LOG_LEVEL)
+        self.tshark_path = tshark_path
 
         self.eventloop = eventloop
         if self.eventloop is None:
@@ -284,7 +285,7 @@ class Capture(object):
         Returns a new tshark process with previously-set parameters.
         """
         xml_type = 'psml' if self.only_summaries else 'pdml'
-        parameters = [get_tshark_path(), '-l', '-n', '-T', xml_type] + self.get_parameters(packet_count=packet_count)
+        parameters = [get_tshark_path(self.tshark_path), '-l', '-n', '-T', xml_type] + self.get_parameters(packet_count=packet_count)
 
         self.log.debug('Creating TShark subprocess with parameters: ' + ' '.join(parameters))
         tshark_process = yield From(asyncio.create_subprocess_exec(*parameters,
@@ -324,7 +325,7 @@ class Capture(object):
         """
         params = []
         if self.display_filter:
-            params += [get_tshark_display_filter_flag(), self.display_filter]
+            params += [get_tshark_display_filter_flag(self.tshark_path), self.display_filter]
         if packet_count:
             params += ['-c', str(packet_count)]
         if all(self.encryption):

--- a/src/pyshark/capture/file_capture.py
+++ b/src/pyshark/capture/file_capture.py
@@ -13,7 +13,7 @@ class FileCapture(Capture):
     """
 
     def __init__(self, input_file=None, keep_packets=True, display_filter=None, only_summaries=False,
-                 decryption_key=None, encryption_type='wpa-pwk'):
+                 decryption_key=None, encryption_type='wpa-pwk', tshark_path=None):
         """
         Creates a packet capture object by reading from file.
 
@@ -26,9 +26,11 @@ class FileCapture(Capture):
         :param decryption_key: Optional key used to encrypt and decrypt captured traffic.
         :param encryption_type: Standard of encryption used in captured traffic (must be either 'WEP', 'WPA-PWD', or
         'WPA-PWK'. Defaults to WPA-PWK).
+        :param tshark_path: Path of the tshark binary
         """
         super(FileCapture, self).__init__(display_filter=display_filter, only_summaries=only_summaries,
-                                          decryption_key=decryption_key, encryption_type=encryption_type)
+                                          decryption_key=decryption_key, encryption_type=encryption_type,
+                                          tshark_path=tshark_path)
         self.input_filename = input_file
         if not isinstance(input_file, basestring):
             self.input_filename = input_file.name

--- a/src/pyshark/capture/inmem_capture.py
+++ b/src/pyshark/capture/inmem_capture.py
@@ -18,7 +18,7 @@ class LinkTypes(object):
 class InMemCapture(Capture):
 
     def __init__(self, bpf_filter=None, display_filter=None, only_summaries=False,
-                  decryption_key=None, encryption_type='wpa-pwk'):
+                  decryption_key=None, encryption_type='wpa-pwk', tshark_path=None):
         """
         Creates a new in-mem capture, a capture capable of receiving binary packets and parsing them using tshark.
         Currently opens a new instance of tshark for every packet buffer,
@@ -30,9 +30,11 @@ class InMemCapture(Capture):
         :param decryption_key: Key used to encrypt and decrypt captured traffic.
         :param encryption_type: Standard of encryption used in captured traffic (must be either 'WEP', 'WPA-PWD',
         or 'WPA-PWK'. Defaults to WPA-PWK).
+        :param tshark_path: Path of the tshark binary
         """
         super(InMemCapture, self).__init__(display_filter=display_filter, only_summaries=only_summaries,
-                                           decryption_key=decryption_key, encryption_type=encryption_type)
+                                           decryption_key=decryption_key, encryption_type=encryption_type,
+                                           tshark_path=tshark_path)
         self.bpf_filter = bpf_filter
         self._packets_to_write = None
         self._current_linktype = None

--- a/src/pyshark/capture/live_capture.py
+++ b/src/pyshark/capture/live_capture.py
@@ -8,7 +8,7 @@ class LiveCapture(Capture):
     """
 
     def __init__(self, interface=None, bpf_filter=None, display_filter=None, only_summaries=False, decryption_key=None,
-                 encryption_type='wpa-pwk'):
+                 encryption_type='wpa-pwk', tshark_path=None):
         """
         Creates a new live capturer on a given interface. Does not start the actual capture itself.
 
@@ -19,13 +19,15 @@ class LiveCapture(Capture):
         :param decryption_key: Optional key used to encrypt and decrypt captured traffic.
         :param encryption_type: Standard of encryption used in captured traffic (must be either 'WEP', 'WPA-PWD', or
         'WPA-PWK'. Defaults to WPA-PWK).
+        :param tshark_path: Path of the tshark binary
         """
         super(LiveCapture, self).__init__(display_filter=display_filter, only_summaries=only_summaries,
-                                          decryption_key=decryption_key, encryption_type=encryption_type)
+                                          decryption_key=decryption_key, encryption_type=encryption_type,
+                                          tshark_path=tshark_path)
         self.bpf_filter = bpf_filter
         
         if interface is None:
-            self.interfaces = get_tshark_interfaces()
+            self.interfaces = get_tshark_interfaces(tshark_path)
         else:
             self.interfaces = [interface]
 

--- a/src/pyshark/capture/remote_capture.py
+++ b/src/pyshark/capture/remote_capture.py
@@ -7,7 +7,7 @@ class RemoteCapture(LiveCapture):
     """
 
     def __init__(self, remote_host, remote_interface, remote_port=2002, bpf_filter=None, only_summaries=False,
-                 decryption_key=None, encryption_type='wpa-pwk'):
+                 decryption_key=None, encryption_type='wpa-pwk', tshark_path=None):
         """
         Creates a new remote capture which will connect to a remote machine which is running rpcapd. Use the sniff() method
         to get packets.
@@ -23,7 +23,9 @@ class RemoteCapture(LiveCapture):
         :param decryption_key: Key used to encrypt and decrypt captured traffic.
         :param encryption_type: Standard of encryption used in captured traffic (must be either 'WEP', 'WPA-PWD',
         or 'WPA-PWK'. Defaults to WPA-PWK).
+        :param tshark_path: Path of the tshark binary
         """
         interface = 'rpcap://%s:%d/%s' % (remote_host, remote_port, remote_interface)
         super(RemoteCapture, self).__init__(interface, bpf_filter=bpf_filter, only_summaries=only_summaries,
-                                            decryption_key=decryption_key, encryption_type=encryption_type)
+                                            decryption_key=decryption_key, encryption_type=encryption_type,
+                                            tshark_path=tshark_path)

--- a/src/pyshark/tshark/tshark.py
+++ b/src/pyshark/tshark/tshark.py
@@ -13,16 +13,21 @@ class TSharkNotFoundException(Exception):
     pass
 
 
-def get_tshark_path():
+def get_tshark_path(tshark_path=None):
     """
-    Finds the path of the tshark executable. If the user has specified a
-    location in config.ini it will be used. Otherwise default locations
-    will be searched.
+    Finds the path of the tshark executable. If the user has provided a path
+    or specified a location in config.ini it will be used. Otherwise default
+    locations will be searched.
 
+    :param tshark_path: Path of the tshark binary
     :raises TSharkNotFoundException in case TShark is not found in any location.
     """
     config = get_config()
     possible_paths = [config.get('tshark', 'tshark_path')]
+
+    # Add the user provided path to the search list
+    if tshark_path is not None:
+        possible_paths.insert(0, tshark_path)
 
     # Windows search order: configuration file's path, common paths.
     if sys.platform.startswith('win'):
@@ -49,30 +54,30 @@ def get_tshark_path():
         'Search these paths: {}'.format(possible_paths)
     )
 
-def get_tshark_version():
-    parameters = [get_tshark_path(), '-v']
+def get_tshark_version(tshark_path=None):
+    parameters = [get_tshark_path(tshark_path), '-v']
     version_output = subprocess.check_output(parameters).decode("ascii")
     version_line = version_output.splitlines()[0]
     version_string = version_line.split()[1]
 
     return version_string
 
-def get_tshark_display_filter_flag():
+def get_tshark_display_filter_flag(tshark_path=None):
     """
     Returns '-Y' for tshark versions >= 1.10.0 and '-R' for older versions.
     """
-    tshark_version = get_tshark_version()
+    tshark_version = get_tshark_version(tshark_path)
     if LooseVersion(tshark_version) >= LooseVersion("1.10.0"):
         return '-Y'
     else:
         return '-R'
 
-def get_tshark_interfaces():
+def get_tshark_interfaces(tshark_path=None):
     """
     Returns a list of interface numbers from the output tshark -D. Used
     internally to capture on multiple interfaces.
     """
-    parameters = [get_tshark_path(), '-D']
+    parameters = [get_tshark_path(tshark_path), '-D']
     tshark_interfaces = subprocess.check_output(parameters).decode("ascii")
     
     return [line.split('.')[0] for line in tshark_interfaces.splitlines()]

--- a/tests/test_tshark.py
+++ b/tests/test_tshark.py
@@ -4,7 +4,17 @@ from pyshark.tshark.tshark import (
     get_tshark_display_filter_flag,
     get_tshark_interfaces,
     get_tshark_version,
+    get_tshark_path,
 )
+
+
+@mock.patch('os.path.exists', autospec=True)
+def test_get_tshark_path(mock_exists):
+    mock_exists.return_value = True
+    actual = get_tshark_path("/some/path/tshark")
+    expected = "/some/path/tshark"
+    assert actual == expected
+
 
 @mock.patch('pyshark.tshark.tshark.subprocess.check_output', autospec=True)
 def test_get_tshark_version(mock_check_output):


### PR DESCRIPTION
I'm trying the use of pyshark for doing some basic tests on a Wireshark dissector plugin. In this use case, one would need to setup a `config.ini` file and modify `config.CONFIG_PATH` in order to be able to load `tshark` from the build directory. It would be great to have an optional parameter instead that one can pass to the `Capture` interface.

This is a first try to do this, by using an optional parameter that is put first on the search list. Another valid approach might be to turn the configuration a modifiable structure (a dict?) so one can put the path there.