### PR TITLE
Add optional 'output_file' parameter to LiveCapture objects and fix hang attempting to iterate an empty FileCapture w/ only_summaries=True

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ includes very little information
 * **param encryption_type**: Standard of encryption used in captured traffic
 (must be either 'WEP', 'WPA-PWD', or 'WPA-PWK'. Defaults to WPA-PWK).
 * **param output_file**: Additionally save captured packets to this file.
+
 ###Reading from a live remote interface:
 
 ```python

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ includes very little information
 * **param decryption_key**: Key used to encrypt and decrypt captured traffic.
 * **param encryption_type**: Standard of encryption used in captured traffic
 (must be either 'WEP', 'WPA-PWD', or 'WPA-PWK'. Defaults to WPA-PWK).
-
+* **param output_file**: Additionally save captured packets to this file.
 ###Reading from a live remote interface:
 
 ```python

--- a/src/pyshark/capture/live_capture.py
+++ b/src/pyshark/capture/live_capture.py
@@ -22,7 +22,8 @@ class LiveCapture(Capture):
         :param output_file: Additionally save live captured packets to this file.
         """
         super(LiveCapture, self).__init__(display_filter=display_filter, only_summaries=only_summaries,
-                                          decryption_key=decryption_key, encryption_type=encryption_type, output_file=output_file)
+                                          decryption_key=decryption_key, encryption_type=encryption_type,
+                                          output_file=output_file)
         self.bpf_filter = bpf_filter
         
         if interface is None:

--- a/src/pyshark/capture/live_capture.py
+++ b/src/pyshark/capture/live_capture.py
@@ -8,7 +8,7 @@ class LiveCapture(Capture):
     """
 
     def __init__(self, interface=None, bpf_filter=None, display_filter=None, only_summaries=False, decryption_key=None,
-                 encryption_type='wpa-pwk'):
+                 encryption_type='wpa-pwk', output_file=None):
         """
         Creates a new live capturer on a given interface. Does not start the actual capture itself.
 
@@ -19,9 +19,10 @@ class LiveCapture(Capture):
         :param decryption_key: Optional key used to encrypt and decrypt captured traffic.
         :param encryption_type: Standard of encryption used in captured traffic (must be either 'WEP', 'WPA-PWD', or
         'WPA-PWK'. Defaults to WPA-PWK).
+        :param output_file: Additionally save live captured packets to this file.
         """
         super(LiveCapture, self).__init__(display_filter=display_filter, only_summaries=only_summaries,
-                                          decryption_key=decryption_key, encryption_type=encryption_type)
+                                          decryption_key=decryption_key, encryption_type=encryption_type, output_file=output_file)
         self.bpf_filter = bpf_filter
         
         if interface is None:

--- a/tests/test_cap_operations.py
+++ b/tests/test_cap_operations.py
@@ -50,10 +50,9 @@ def test_getting_packet_summary(lazy_simple_capture):
     assert lazy_simple_capture[0]._fields
 
 def _iterate_capture_object(cap_obj, q):
-    try:
-        cap_obj.next()
-    except StopIteration as e:
-        q.put(e)
+    for packet in cap_obj:
+        pass
+    q.put(True)
 
 def test_iterate_empty_psml_capture(lazy_simple_capture):
     lazy_simple_capture.only_summaries = True
@@ -63,9 +62,9 @@ def test_iterate_empty_psml_capture(lazy_simple_capture):
     p.start()
     p.join(2)
     try:
-        actual_result = q.get_nowait()
+        no_hang = q.get_nowait()
     except Empty:
-        actual_result = None
+        no_hang = False
     if p.is_alive():
         p.terminate()
-    assert isinstance(actual_result, StopIteration)
+    assert no_hang


### PR DESCRIPTION
Add output_file parameter to base Capture class and expose it for LiveCapture objects so a file can be created and saved to be inspected using FileCapture later.  This is useful for applying disparate display_filters against a FileCapture object at a later time.

Fix a bug where pyshark would hang attempting to iterate a FileCapture w/ only_summaries=True that had no data due to an applied display_filter.  The root cause was only checking for a 'structure' psml element that would never appear before EOF.  Adding a StreamReader EOF check (empty read) to break out of the loop resolves the problem.  Also added a unit test to add coverage for this scenario and confirmed it would fail when removing the patched code.