### PR TITLE
Updating get_tshark_version() to support multiple version strings

### DIFF
--- a/src/pyshark/tshark/tshark.py
+++ b/src/pyshark/tshark/tshark.py
@@ -101,7 +101,7 @@ def get_tshark_version(tshark_path=None):
     parameters = [get_tshark_path(tshark_path), '-v']
     version_output = check_output(parameters).decode("ascii")
     version_line = version_output.splitlines()[0]
-    pattern = '.*\s(\d+\.\d+\.\d+)\s.*'  # match " #.#.# " version pattern
+    pattern = '.*\s(\d+\.\d+\.\d+).*'  # match " #.#.#" version pattern
     m = re.match(pattern, version_line)
     if not m:
         raise TSharkVersionException('Unable to parse TShark version from: {}'.format(version_line))


### PR DESCRIPTION
Version strings for TSHARK are displayed differently for different installations.
The following were found as a difference between Windows and Linux:

win_version_line = 'TShark 1.12.8 (v1.12.8-0-g5b6e543 from master-1.12)'
lnx_version_line = 'TShark (Wireshark) 2.0.0 (SVN Rev Unknown from unknown)'
lnx_tshark_line = 'TShark 1.2.3'

The current implementation returned "(Wireshark)" in the Linux case, and caused an error in version comparision performed in 'get_tshark_display_filter_flag()'.