### PR TITLE
Adding 'override_prefs' to Capture in order to support the ability to override arbitrary tshark preferences

### DIFF
--- a/src/pyshark/capture/capture.py
+++ b/src/pyshark/capture/capture.py
@@ -31,7 +31,7 @@ class Capture(object):
 
     def __init__(self, display_filter=None, only_summaries=False, eventloop=None,
                  decryption_key=None, encryption_type='wpa-pwd', output_file=None,
-                 decode_as=None, tshark_path=None):
+                 decode_as=None, tshark_path=None, override_prefs=None):
         self._packets = []
         self.current_packet = 0
         self.display_filter = display_filter
@@ -42,6 +42,7 @@ class Capture(object):
         self.decode_as = decode_as
         self.log = logbook.Logger(self.__class__.__name__, level=self.DEFAULT_LOG_LEVEL)
         self.tshark_path = tshark_path
+        self.override_prefs = override_prefs
         self.debug = False
 
         self.eventloop = eventloop
@@ -348,6 +349,10 @@ class Capture(object):
         if all(self.encryption):
             params += ['-o', 'wlan.enable_decryption:TRUE', '-o', 'uat:80211_keys:"' + self.encryption[1] + '","' +
                                                                   self.encryption[0] + '"']
+        if self.override_prefs:
+            for preference_name, preference_value in self.override_prefs.items():
+                params += ['-o', '{}:{}'.format(preference_name, preference_value)]
+
         if self.output_file:
             params += ['-w', self.output_file]
 

--- a/src/pyshark/capture/capture.py
+++ b/src/pyshark/capture/capture.py
@@ -351,6 +351,8 @@ class Capture(object):
                                                                   self.encryption[0] + '"']
         if self.override_prefs:
             for preference_name, preference_value in self.override_prefs.items():
+                if all(self.encryption) and preference_name in ('wlan.enable_decryption', 'uat:80211_keys'):
+                    continue  # skip if override preferences also given via --encryption options
                 params += ['-o', '{}:{}'.format(preference_name, preference_value)]
 
         if self.output_file:

--- a/src/pyshark/capture/capture.py
+++ b/src/pyshark/capture/capture.py
@@ -353,7 +353,7 @@ class Capture(object):
             for preference_name, preference_value in self.override_prefs.items():
                 if all(self.encryption) and preference_name in ('wlan.enable_decryption', 'uat:80211_keys'):
                     continue  # skip if override preferences also given via --encryption options
-                params += ['-o', '{}:{}'.format(preference_name, preference_value)]
+                params += ['-o', '{0}:{1}'.format(preference_name, preference_value)]
 
         if self.output_file:
             params += ['-w', self.output_file]

--- a/src/pyshark/capture/file_capture.py
+++ b/src/pyshark/capture/file_capture.py
@@ -13,7 +13,8 @@ class FileCapture(Capture):
     """
 
     def __init__(self, input_file=None, keep_packets=True, display_filter=None, only_summaries=False,
-                 decryption_key=None, encryption_type='wpa-pwk', decode_as=None, tshark_path=None):
+                 decryption_key=None, encryption_type='wpa-pwk', decode_as=None, tshark_path=None,
+                 override_prefs=None):
         """
         Creates a packet capture object by reading from file.
 
@@ -26,14 +27,15 @@ class FileCapture(Capture):
         :param decryption_key: Optional key used to encrypt and decrypt captured traffic.
         :param encryption_type: Standard of encryption used in captured traffic (must be either 'WEP', 'WPA-PWD', or
         'WPA-PWK'. Defaults to WPA-PWK).
-        :param tshark_path: Path of the tshark binary
         :param decode_as: A dictionary of {decode_criterion_string: decode_as_protocol} that are used to tell tshark
         to decode protocols in situations it wouldn't usually, for instance {'tcp.port==8888': 'http'} would make
         it attempt to decode any port 8888 traffic as HTTP. See tshark documentation for details.
+        :param tshark_path: Path of the tshark binary
+        :param override_prefs: A dictionary of tshark preferences to override, {PREFERENCE_NAME, PREFERENCE_VALUE, ...}.
         """
         super(FileCapture, self).__init__(display_filter=display_filter, only_summaries=only_summaries,
                                           decryption_key=decryption_key, encryption_type=encryption_type,
-                                          decode_as=decode_as, tshark_path=tshark_path)
+                                          decode_as=decode_as, tshark_path=tshark_path, override_prefs=override_prefs)
         self.input_filename = input_file
         if not isinstance(input_file, basestring):
             self.input_filename = input_file.name

--- a/src/pyshark/capture/inmem_capture.py
+++ b/src/pyshark/capture/inmem_capture.py
@@ -18,7 +18,8 @@ class LinkTypes(object):
 class InMemCapture(Capture):
 
     def __init__(self, bpf_filter=None, display_filter=None, only_summaries=False,
-                  decryption_key=None, encryption_type='wpa-pwk', decode_as=None, tshark_path=None):
+                  decryption_key=None, encryption_type='wpa-pwk', decode_as=None, tshark_path=None,
+                  override_prefs=None):
         """
         Creates a new in-mem capture, a capture capable of receiving binary packets and parsing them using tshark.
         Currently opens a new instance of tshark for every packet buffer,
@@ -30,10 +31,11 @@ class InMemCapture(Capture):
         :param decryption_key: Key used to encrypt and decrypt captured traffic.
         :param encryption_type: Standard of encryption used in captured traffic (must be either 'WEP', 'WPA-PWD',
         or 'WPA-PWK'. Defaults to WPA-PWK).
-        :param tshark_path: Path of the tshark binary
         :param decode_as: A dictionary of {decode_criterion_string: decode_as_protocol} that are used to tell tshark
         to decode protocols in situations it wouldn't usually, for instance {'tcp.port==8888': 'http'} would make
         it attempt to decode any port 8888 traffic as HTTP. See tshark documentation for details.
+        :param tshark_path: Path of the tshark binary
+        :param override_prefs: A dictionary of tshark preferences to override, {PREFERENCE_NAME, PREFERENCE_VALUE, ...}.
         """
         super(InMemCapture, self).__init__(display_filter=display_filter, only_summaries=only_summaries,
                                            decryption_key=decryption_key, encryption_type=encryption_type,

--- a/src/pyshark/capture/live_capture.py
+++ b/src/pyshark/capture/live_capture.py
@@ -8,7 +8,7 @@ class LiveCapture(Capture):
     """
 
     def __init__(self, interface=None, bpf_filter=None, display_filter=None, only_summaries=False, decryption_key=None,
-                 encryption_type='wpa-pwk', output_file=None, decode_as=None, tshark_path=None):
+                 encryption_type='wpa-pwk', output_file=None, decode_as=None, tshark_path=None, override_prefs=None):
         """
         Creates a new live capturer on a given interface. Does not start the actual capture itself.
 
@@ -19,15 +19,17 @@ class LiveCapture(Capture):
         :param decryption_key: Optional key used to encrypt and decrypt captured traffic.
         :param encryption_type: Standard of encryption used in captured traffic (must be either 'WEP', 'WPA-PWD', or
         'WPA-PWK'. Defaults to WPA-PWK).
-        :param tshark_path: Path of the tshark binary
         :param output_file: Additionally save live captured packets to this file.
         :param decode_as: A dictionary of {decode_criterion_string: decode_as_protocol} that are used to tell tshark
         to decode protocols in situations it wouldn't usually, for instance {'tcp.port==8888': 'http'} would make
         it attempt to decode any port 8888 traffic as HTTP. See tshark documentation for details.
+        :param tshark_path: Path of the tshark binary
+        :param override_prefs: A dictionary of tshark preferences to override, {PREFERENCE_NAME, PREFERENCE_VALUE, ...}.
         """
         super(LiveCapture, self).__init__(display_filter=display_filter, only_summaries=only_summaries,
                                           decryption_key=decryption_key, encryption_type=encryption_type,
-                                          output_file=output_file, decode_as=decode_as, tshark_path=tshark_path)
+                                          output_file=output_file, decode_as=decode_as, tshark_path=tshark_path,
+                                          override_prefs=override_prefs)
         self.bpf_filter = bpf_filter
         
         if interface is None:

--- a/src/pyshark/capture/live_ring_capture.py
+++ b/src/pyshark/capture/live_ring_capture.py
@@ -5,7 +5,9 @@ class LiveRingCapture(LiveCapture):
     Represents a live ringbuffer capture on a network interface.
     """
 
-    def __init__(self, ring_file_size=1024, num_ring_files=1, ring_file_name='/tmp/pyshark.pcap', interface=None, bpf_filter=None, display_filter=None, only_summaries=False, decryption_key=None, encryption_type='wpa-pwk', decode_as=None, tshark_path=None):
+    def __init__(self, ring_file_size=1024, num_ring_files=1, ring_file_name='/tmp/pyshark.pcap', interface=None,
+                 bpf_filter=None, display_filter=None, only_summaries=False, decryption_key=None,
+                 encryption_type='wpa-pwk', decode_as=None, tshark_path=None, override_prefs=None):
         """
         Creates a new live capturer on a given interface. Does not start the actual capture itself.
         :param ring_file_size: Size of the ring file in kB, default is 1024
@@ -19,13 +21,15 @@ class LiveRingCapture(LiveCapture):
         :param encryption_type: Standard of encryption used in captured traffic (must be either 'WEP', 'WPA-PWD', or
         'WPA-PWK'. Defaults to WPA-PWK).
         :param decode_as: A dictionary of {decode_criterion_string: decode_as_protocol} that are used to tell tshark
-        :param tshark_path: Path of the tshark binary
         to decode protocols in situations it wouldn't usually, for instance {'tcp.port==8888': 'http'} would make
         it attempt to decode any port 8888 traffic as HTTP. See tshark documentation for details.
+        :param tshark_path: Path of the tshark binary
+        :param override_prefs: A dictionary of tshark preferences to override, {PREFERENCE_NAME, PREFERENCE_VALUE, ...}.
         """
         super(LiveRingCapture, self).__init__(interface, bpf_filter=bpf_filter, display_filter=display_filter, only_summaries=only_summaries,
                                               decryption_key=decryption_key, encryption_type=encryption_type,
-                                              tshark_path=tshark_path, decode_as=decode_as)
+                                              tshark_path=tshark_path, decode_as=decode_as,
+                                              override_prefs=override_prefs)
 
         self.ring_file_size = ring_file_size
         self.num_ring_files = num_ring_files

--- a/src/pyshark/capture/remote_capture.py
+++ b/src/pyshark/capture/remote_capture.py
@@ -7,10 +7,10 @@ class RemoteCapture(LiveCapture):
     """
 
     def __init__(self, remote_host, remote_interface, remote_port=2002, bpf_filter=None, only_summaries=False,
-                 decryption_key=None, encryption_type='wpa-pwk', decode_as=None, tshark_path=None):
+                 decryption_key=None, encryption_type='wpa-pwk', decode_as=None, tshark_path=None, override_prefs=None):
         """
-        Creates a new remote capture which will connect to a remote machine which is running rpcapd. Use the sniff() method
-        to get packets.
+        Creates a new remote capture which will connect to a remote machine which is running rpcapd. Use the sniff()
+        method to get packets.
         Note: The remote machine should have rpcapd running in null authentication mode (-n). Be warned that the traffic
         is unencrypted!
 
@@ -31,4 +31,4 @@ class RemoteCapture(LiveCapture):
         interface = 'rpcap://%s:%d/%s' % (remote_host, remote_port, remote_interface)
         super(RemoteCapture, self).__init__(interface, bpf_filter=bpf_filter, only_summaries=only_summaries,
                                             decryption_key=decryption_key, encryption_type=encryption_type,
-                                            tshark_path=tshark_path, decode_as=decode_as)
+                                            tshark_path=tshark_path, decode_as=decode_as, override_prefs=override_prefs)

--- a/tests/capture/test_capture.py
+++ b/tests/capture/test_capture.py
@@ -48,11 +48,11 @@ def test_capture_gets_encryption_and_override_perfs():
                     encryption_type=valid_encryption_type,
                     override_prefs={'esp.enable_null_encryption_decode_heuristic': 'TRUE',
                                     'wlan.enable_decryption': 'TRUE',
-                                    'uat:80211_keys': '"{}","helloworld"'.format(valid_encryption_type)})
+                                    'uat:80211_keys': '"{0}","helloworld"'.format(valid_encryption_type)})
         params = c.get_parameters()
         expected_results = ('esp.enable_null_encryption_decode_heuristic:TRUE',
                             'wlan.enable_decryption:TRUE',
-                            'uat:80211_keys:"{}","helloworld"'.format(valid_encryption_type))
+                            'uat:80211_keys:"{0}","helloworld"'.format(valid_encryption_type))
         option_count = 0
         start_idx = 0
         override_index = params.index('-o')

--- a/tests/capture/test_capture.py
+++ b/tests/capture/test_capture.py
@@ -17,3 +17,57 @@ def test_capture_gets_multiple_decoding_parameters():
     possible_results.remove(params[decode_index + 1])
     decode_index = params.index('-d', decode_index + 1)
     assert params[decode_index + 1] == possible_results[0] 
+
+
+def test_capture_gets_override_perfs():
+    c = Capture(override_prefs={'esp.enable_null_encryption_decode_heuristic': 'TRUE'})
+    params = c.get_parameters()
+    override_index = params.index('-o')
+    override_actual_value = params[override_index +1]
+    assert override_actual_value == 'esp.enable_null_encryption_decode_heuristic:TRUE'
+
+
+def test_capture_gets_multiple_override_perfs():
+    c = Capture(override_prefs={'esp.enable_null_encryption_decode_heuristic': 'TRUE',
+                                'tcp.ls_payload_display_len':'80'})
+    params = c.get_parameters()
+    expected_results = ('esp.enable_null_encryption_decode_heuristic:TRUE',
+                        'tcp.ls_payload_display_len:80')
+    start_idx = 0
+    for count in range(len(expected_results)):
+        override_index = params.index('-o', start_idx)
+        override_actual_value = params[override_index +1]
+        assert override_actual_value in expected_results
+        # increment index
+        start_idx = override_index + 1
+
+def test_capture_gets_encryption_and_override_perfs():
+    temp_c = Capture()
+    for valid_encryption_type in temp_c.SUPPORTED_ENCRYPTION_STANDARDS:
+        c = Capture(decryption_key='helloworld',
+                    encryption_type=valid_encryption_type,
+                    override_prefs={'esp.enable_null_encryption_decode_heuristic': 'TRUE',
+                                    'wlan.enable_decryption': 'TRUE',
+                                    'uat:80211_keys': '"{}","helloworld"'.format(valid_encryption_type)})
+        params = c.get_parameters()
+        expected_results = ('esp.enable_null_encryption_decode_heuristic:TRUE',
+                            'wlan.enable_decryption:TRUE',
+                            'uat:80211_keys:"{}","helloworld"'.format(valid_encryption_type))
+        option_count = 0
+        start_idx = 0
+        override_index = params.index('-o')
+        actual_parameter_options = []
+        while True:
+            try:
+                override_index = params.index('-o', start_idx)
+            except ValueError:
+                # no more '-o' options
+                break
+            override_actual_value = params[override_index +1]
+            actual_parameter_options.append(override_actual_value)
+            assert override_actual_value in expected_results
+            # increment index
+            start_idx = override_index + 1
+        assert set(actual_parameter_options) == set(expected_results)
+        assert len(actual_parameter_options) == len(expected_results)
+


### PR DESCRIPTION
Method to resolve issue:
"no interface to add override parameters (can't easily apply wsp.enable_null_encryption_decode_heuristic: TRUE)" #118


This adds a new 'override_prefs' item to the init of Capture and related objects subclassing the Capture object.

Using 'preferences' in place of 'parameters' to match tshark terminology.

:param override_prefs: A dictionary of tshark preferences to override, {PREFERENCE_NAME, PREFERENCE_VALUE, ...}.

There is overlap in what this option provides and the existing decryption_key & encryption_type already provide. The current implementation supports the ability to apply the related encryption preference setting using EITHER decryption_key & encryption_type OR override_perfs.
