### PR TITLE
Make sure BPF filter applies to all interfaces

### DIFF
--- a/src/pyshark/capture/live_capture.py
+++ b/src/pyshark/capture/live_capture.py
@@ -1,6 +1,10 @@
 from pyshark.capture.capture import Capture
 from pyshark.tshark.tshark import get_tshark_interfaces
+import sys
 
+# Define basestring as str if we're in python3.
+if sys.version_info >= (3, 0):
+    basestring = str
 
 class LiveCapture(Capture):
     """

--- a/src/pyshark/capture/live_capture.py
+++ b/src/pyshark/capture/live_capture.py
@@ -45,10 +45,10 @@ class LiveCapture(Capture):
         Returns the special tshark parameters to be used according to the configuration of this class.
         """
         params = super(LiveCapture, self).get_parameters(packet_count=packet_count)
-        for interface in self.interfaces:
-            params += ['-i', interface]
         if self.bpf_filter:
             params += ['-f', self.bpf_filter]
+        for interface in self.interfaces:
+            params += ['-i', interface]
         return params
 
     # Backwards compatibility

--- a/src/pyshark/capture/live_ring_capture.py
+++ b/src/pyshark/capture/live_ring_capture.py
@@ -40,9 +40,5 @@ class LiveRingCapture(LiveCapture):
         Returns the special tshark parameters to be used according to the configuration of this class.
         """
         params = super(LiveRingCapture, self).get_parameters(packet_count=packet_count)
-        for interface in self.interfaces:
-            params += ['-i', interface]
-        if self.bpf_filter:
-            params += ['-f', self.bpf_filter]
         params += ['-b', 'filesize:' + str(self.ring_file_size), '-b', 'files:' + str(self.num_ring_files), '-w', self.ring_file_name, '-P']
         return params


### PR DESCRIPTION
BFP filter should apply to all interfaces (as there is not option to set it per interface).
This is done by setting the -f (bpf filter) parameter before the first -i (interface).
