### PR TITLE
Added disable_protocol parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ packet capture file (PCAP, PCAP-NG..) or a TShark xml.
 before reading it.
 * **param only_summaries**: Only produce packet summaries, much faster but includes
 very little information
+* **param disable_protocol**: Disable detection of a protocol (tshark > version 2)
 * **param decryption_key**: Key used to encrypt and decrypt captured traffic.
 * **param encryption_type**: Standard of encryption used in captured traffic (must
 be either 'WEP', 'WPA-PWD', or 'WPA-PWK'. Defaults to WPA-PWK.
@@ -81,6 +82,7 @@ the first available.
 * **param display_filter**: Display (wireshark) filter to use.
 * **param only_summaries**: Only produce packet summaries, much faster but
 includes very little information
+* **param disable_protocol**: Disable detection of a protocol (tshark > version 2)
 * **param decryption_key**: Key used to encrypt and decrypt captured traffic.
 * **param encryption_type**: Standard of encryption used in captured traffic
 (must be either 'WEP', 'WPA-PWD', or 'WPA-PWK'. Defaults to WPA-PWK).
@@ -110,6 +112,7 @@ the first available.
 * **param display_filter**: Display (wireshark) filter to use.
 * **param only_summaries**: Only produce packet summaries, much faster but
 includes very little information
+* **param disable_protocol**: Disable detection of a protocol (tshark > version 2)
 * **param decryption_key**: Key used to encrypt and decrypt captured traffic.
 * **param encryption_type**: Standard of encryption used in captured traffic
 (must be either 'WEP', 'WPA-PWD', or 'WPA-PWK'. Defaults to WPA-PWK).
@@ -136,6 +139,7 @@ true interface name (i.e. \\Device\\NPF_..).
 reading.
 * **param only_summaries**: Only produce packet summaries, much faster but
 includes very little information
+* **param disable_protocol**: Disable detection of a protocol (tshark > version 2)
 * **param decryption_key**: Key used to encrypt and decrypt captured traffic.
 * **param encryption_type**: Standard of encryption used in captured traffic
 (must be either 'WEP', 'WPA-PWD', or 'WPA-PWK'. Defaults to WPA-PWK).

--- a/src/pyshark/capture/capture.py
+++ b/src/pyshark/capture/capture.py
@@ -38,7 +38,8 @@ class Capture(object):
 
     def __init__(self, display_filter=None, only_summaries=False, eventloop=None,
                  decryption_key=None, encryption_type='wpa-pwd', output_file=None,
-                 decode_as=None, tshark_path=None, override_prefs=None, capture_filter=None):
+                 decode_as=None,  disable_protocol=None, tshark_path=None,
+                 override_prefs=None, capture_filter=None):
         self._packets = []
         self.current_packet = 0
         self.display_filter = display_filter
@@ -48,6 +49,7 @@ class Capture(object):
         self.running_processes = set()
         self.loaded = False
         self.decode_as = decode_as
+        self.disable_protocol = disable_protocol
         self.log = logbook.Logger(self.__class__.__name__, level=self.DEFAULT_LOG_LEVEL)
         self.tshark_path = tshark_path
         self.override_prefs = override_prefs
@@ -378,6 +380,10 @@ class Capture(object):
         if self.decode_as:
             for criterion, decode_as_proto in self.decode_as.items():
                 params += ['-d', ','.join([criterion.strip(), decode_as_proto.strip()])]
+
+        if self.disable_protocol:
+            params += ['--disable-protocol', self.disable_protocol.strip()]
+
         return params
 
     def __iter__(self):

--- a/src/pyshark/capture/file_capture.py
+++ b/src/pyshark/capture/file_capture.py
@@ -13,8 +13,8 @@ class FileCapture(Capture):
     """
 
     def __init__(self, input_file=None, keep_packets=True, display_filter=None, only_summaries=False,
-                 decryption_key=None, encryption_type='wpa-pwk', decode_as=None, tshark_path=None,
-                 override_prefs=None):
+                 decryption_key=None, encryption_type='wpa-pwk', decode_as=None,
+                 disable_protocol=None, tshark_path=None, override_prefs=None):
         """
         Creates a packet capture object by reading from file.
 
@@ -31,10 +31,12 @@ class FileCapture(Capture):
         it attempt to decode any port 8888 traffic as HTTP. See tshark documentation for details.
         :param tshark_path: Path of the tshark binary
         :param override_prefs: A dictionary of tshark preferences to override, {PREFERENCE_NAME: PREFERENCE_VALUE, ...}.
+        :param disable_protocol: Tells tshark to remove a dissector for a specifc protocol.
         """
         super(FileCapture, self).__init__(display_filter=display_filter, only_summaries=only_summaries,
                                           decryption_key=decryption_key, encryption_type=encryption_type,
-                                          decode_as=decode_as, tshark_path=tshark_path, override_prefs=override_prefs)
+                                          decode_as=decode_as, disable_protocol=disable_protocol, tshark_path=tshark_path,
+                                          override_prefs=override_prefs)
         self.input_filename = input_file
         if not isinstance(input_file, basestring):
             self.input_filename = input_file.name

--- a/src/pyshark/capture/inmem_capture.py
+++ b/src/pyshark/capture/inmem_capture.py
@@ -18,8 +18,8 @@ class LinkTypes(object):
 class InMemCapture(Capture):
 
     def __init__(self, bpf_filter=None, display_filter=None, only_summaries=False,
-                  decryption_key=None, encryption_type='wpa-pwk', decode_as=None, tshark_path=None,
-                  override_prefs=None):
+                  decryption_key=None, encryption_type='wpa-pwk', decode_as=None,
+                  disable_protocol=None, tshark_path=None, override_prefs=None):
         """
         Creates a new in-mem capture, a capture capable of receiving binary packets and parsing them using tshark.
         Currently opens a new instance of tshark for every packet buffer,
@@ -36,10 +36,13 @@ class InMemCapture(Capture):
         it attempt to decode any port 8888 traffic as HTTP. See tshark documentation for details.
         :param tshark_path: Path of the tshark binary
         :param override_prefs: A dictionary of tshark preferences to override, {PREFERENCE_NAME: PREFERENCE_VALUE, ...}.
+        :param disable_protocol: Tells tshark to remove a dissector for a specifc protocol.
+
         """
         super(InMemCapture, self).__init__(display_filter=display_filter, only_summaries=only_summaries,
                                            decryption_key=decryption_key, encryption_type=encryption_type,
-                                           decode_as=decode_as, tshark_path=tshark_path)
+                                           decode_as=decode_as, disable_protocol=disable_protocol,
+                                           tshark_path=tshark_path)
         self.bpf_filter = bpf_filter
         self._packets_to_write = None
         self._current_linktype = None

--- a/src/pyshark/capture/live_capture.py
+++ b/src/pyshark/capture/live_capture.py
@@ -8,7 +8,8 @@ class LiveCapture(Capture):
     """
 
     def __init__(self, interface=None, bpf_filter=None, display_filter=None, only_summaries=False, decryption_key=None,
-                 encryption_type='wpa-pwk', output_file=None, decode_as=None, tshark_path=None, override_prefs=None, capture_filter=None):
+                 encryption_type='wpa-pwk', output_file=None, decode_as=None, disable_protocol=None, tshark_path=None,
+                 override_prefs=None, capture_filter=None):
         """
         Creates a new live capturer on a given interface. Does not start the actual capture itself.
 
@@ -26,13 +27,15 @@ class LiveCapture(Capture):
         :param tshark_path: Path of the tshark binary
         :param override_prefs: A dictionary of tshark preferences to override, {PREFERENCE_NAME: PREFERENCE_VALUE, ...}.
         :param capture_filter: Capture (wireshark) filter to use.
+        :param disable_protocol: Tells tshark to remove a dissector for a specifc protocol.
         """
         super(LiveCapture, self).__init__(display_filter=display_filter, only_summaries=only_summaries,
                                           decryption_key=decryption_key, encryption_type=encryption_type,
-                                          output_file=output_file, decode_as=decode_as, tshark_path=tshark_path,
-                                          override_prefs=override_prefs, capture_filter=capture_filter)
+                                          output_file=output_file, decode_as=decode_as, disable_protocol=disable_protocol,
+                                          tshark_path=tshark_path, override_prefs=override_prefs,
+                                          capture_filter=capture_filter)
         self.bpf_filter = bpf_filter
-        
+
         if interface is None:
             self.interfaces = get_tshark_interfaces(tshark_path)
         elif isinstance(interface, basestring):

--- a/src/pyshark/capture/live_ring_capture.py
+++ b/src/pyshark/capture/live_ring_capture.py
@@ -7,7 +7,8 @@ class LiveRingCapture(LiveCapture):
 
     def __init__(self, ring_file_size=1024, num_ring_files=1, ring_file_name='/tmp/pyshark.pcap', interface=None,
                  bpf_filter=None, display_filter=None, only_summaries=False, decryption_key=None,
-                 encryption_type='wpa-pwk', decode_as=None, tshark_path=None, override_prefs=None):
+                 encryption_type='wpa-pwk', decode_as=None, disable_protocol=None,
+                 tshark_path=None, override_prefs=None):
         """
         Creates a new live capturer on a given interface. Does not start the actual capture itself.
         :param ring_file_size: Size of the ring file in kB, default is 1024
@@ -25,10 +26,11 @@ class LiveRingCapture(LiveCapture):
         it attempt to decode any port 8888 traffic as HTTP. See tshark documentation for details.
         :param tshark_path: Path of the tshark binary
         :param override_prefs: A dictionary of tshark preferences to override, {PREFERENCE_NAME: PREFERENCE_VALUE, ...}.
+        :param disable_protocol: Tells tshark to remove a dissector for a specifc protocol.
         """
         super(LiveRingCapture, self).__init__(interface, bpf_filter=bpf_filter, display_filter=display_filter, only_summaries=only_summaries,
                                               decryption_key=decryption_key, encryption_type=encryption_type,
-                                              tshark_path=tshark_path, decode_as=decode_as,
+                                              tshark_path=tshark_path, decode_as=decode_as, disable_protocol=disable_protocol,
                                               override_prefs=override_prefs)
 
         self.ring_file_size = ring_file_size

--- a/src/pyshark/capture/remote_capture.py
+++ b/src/pyshark/capture/remote_capture.py
@@ -7,7 +7,8 @@ class RemoteCapture(LiveCapture):
     """
 
     def __init__(self, remote_host, remote_interface, remote_port=2002, bpf_filter=None, only_summaries=False,
-                 decryption_key=None, encryption_type='wpa-pwk', decode_as=None, tshark_path=None, override_prefs=None):
+                 decryption_key=None, encryption_type='wpa-pwk', decode_as=None,
+                 disable_protocol=None,tshark_path=None, override_prefs=None):
         """
         Creates a new remote capture which will connect to a remote machine which is running rpcapd. Use the sniff()
         method to get packets.
@@ -28,8 +29,10 @@ class RemoteCapture(LiveCapture):
         it attempt to decode any port 8888 traffic as HTTP. See tshark documentation for details.
         :param tshark_path: Path of the tshark binary
         :param override_prefs: A dictionary of tshark preferences to override, {PREFERENCE_NAME: PREFERENCE_VALUE, ...}.
+        :param disable_protocol: Tells tshark to remove a dissector for a specifc protocol.
         """
         interface = 'rpcap://%s:%d/%s' % (remote_host, remote_port, remote_interface)
         super(RemoteCapture, self).__init__(interface, bpf_filter=bpf_filter, only_summaries=only_summaries,
                                             decryption_key=decryption_key, encryption_type=encryption_type,
-                                            tshark_path=tshark_path, decode_as=decode_as, override_prefs=override_prefs)
+                                            tshark_path=tshark_path, decode_as=decode_as,  disable_protocol=disable_protocol,
+                                            override_prefs=override_prefs)


### PR DESCRIPTION
In a pet project of mine using this library I needed to disable a specific protocol due to a dissector clash leading to wrong output.
As there is a relatively new parameter for tshark I patched the parameter into the library to use it.
