### PR TITLE
Layer to take into account nested fields

### DIFF
--- a/src/pyshark/packet/layer.py
+++ b/src/pyshark/packet/layer.py
@@ -163,10 +163,20 @@ class Layer(Pickleable):
         attributes = dict(obj.attrib)
 
         fields = [self.objectify(field) for field in obj.findall('./field')]
-        subfield = fields[0] if len(fields) == 1 else fields if fields else None
+        if len(fields) == 1:
+            subfield = fields[0]
+        elif fields:
+            subfield = fields
+        else:
+            subfield = None
 
         fields = [self.objectify(field) for field in obj.findall('./proto')]
-        subproto = fields[0] if len(fields) == 1 else fields if fields else None
+        if len(fields) == 1:
+            subproto = fields[0]
+        elif fields:
+            subproto = fields
+        else:
+            subproto = None
 
         fld_obj = LayerField(field=subfield, proto=subproto, **attributes)
         return fld_obj

--- a/src/pyshark/packet/layer.py
+++ b/src/pyshark/packet/layer.py
@@ -198,6 +198,13 @@ class Layer(Pickleable):
         return field
 
     @property
+    def all_fields(self):
+        """
+        Return all LayerFieldContainer items in Layer
+        """
+        return self._all_fields
+
+    @property
     def _field_prefix(self):
         """
         Prefix to field names in the XML.

--- a/src/pyshark/packet/packet.py
+++ b/src/pyshark/packet/packet.py
@@ -114,6 +114,20 @@ class Packet(Pickleable):
         return self.layers[-1].layer_name.upper()
 
     @property
+    def layer_names(self):
+        """
+        Returns all layer names
+        """
+        return [layer.layer_name for layer in self.layers]
+
+    @property
+    def all_layers(self):
+        """
+        Returns list of layers in packet
+        """
+        return self.layers
+
+    @property
     def transport_layer(self):
         for layer in consts.TRANSPORT_LAYERS:
             if layer in self:
@@ -125,4 +139,4 @@ class Packet(Pickleable):
         This is in order to retrieve layers which appear multiple times in the same packet (i.e. double VLAN) which cannot be
         retrieved by easier means.
         """
-        return [layer for layer in self.layers if layer.layer_name.lower() == layer_name.lower()]   
+        return [layer for layer in self.layers if layer.layer_name.lower() == layer_name.lower()]


### PR DESCRIPTION
## Description
There are now two issues with nested fields not being parsed correctly by the Layer class init.
* https://github.com/KimiNewt/pyshark/issues/102
* https://github.com/KimiNewt/pyshark/issues/160

The issues both describe the same problem stemming from the use of ".//field" rather than "./field", which flattens the tree structure, thus discarding data.

## Solution
* Switched to recursively parsing fields with "./field".
* Added field and proto attributes to LayerField and a recursing function.

The proto I put in because I've encountered a few instances where a field has contained a proto.
I aimed to make this backwards compatible so that a flat structure is still parsed correctly as a flat structure.

## Review
@CapnHeiner (opener of https://github.com/KimiNewt/pyshark/issues/160)