### PR TITLE
Check for the windows platform before starting monitor mode

### DIFF
--- a/src/pyshark/capture/live_capture.py
+++ b/src/pyshark/capture/live_capture.py
@@ -41,6 +41,9 @@ class LiveCapture(Capture):
         self.bpf_filter = bpf_filter
         self.monitor_mode = monitor_mode
 
+        if sys.platform == 'win32' and monitor_mode:
+            raise WindowsError('Monitor mode is not supported by the Windows platform')
+
         if interface is None:
             self.interfaces = get_tshark_interfaces(tshark_path)
         elif isinstance(interface, basestring):
@@ -60,7 +63,7 @@ class LiveCapture(Capture):
         else:
             for interface in self.interfaces:
                 params += ['-i', interface]
-                
+
         return params
 
     # Backwards compatibility


### PR DESCRIPTION
Because WinPcap does not support monitor mode, running pyshark in monitor mode gives a system crash message. Its nicer to thow an exception in the application itself. https://wiki.wireshark.org/CaptureSetup/WLAN#Monitor_mode