### PR TITLE
Using tshark JSON output to speed up pyshark

### DIFF
--- a/src/pyshark/capture/file_capture.py
+++ b/src/pyshark/capture/file_capture.py
@@ -14,7 +14,8 @@ class FileCapture(Capture):
 
     def __init__(self, input_file=None, keep_packets=True, display_filter=None, only_summaries=False,
                  decryption_key=None, encryption_type='wpa-pwk', decode_as=None,
-                 disable_protocol=None, tshark_path=None, override_prefs=None):
+                 disable_protocol=None, tshark_path=None, override_prefs=None,
+                 use_json=False):
         """
         Creates a packet capture object by reading from file.
 
@@ -31,12 +32,14 @@ class FileCapture(Capture):
         it attempt to decode any port 8888 traffic as HTTP. See tshark documentation for details.
         :param tshark_path: Path of the tshark binary
         :param override_prefs: A dictionary of tshark preferences to override, {PREFERENCE_NAME: PREFERENCE_VALUE, ...}.
-        :param disable_protocol: Tells tshark to remove a dissector for a specifc protocol.
+        :param disable_protocol: Tells tshark to remove a dissector for a specific protocol.
+        :param use_json: Uses tshark in JSON mode (EXPERIMENTAL). It is a good deal faster than XML
+        but also has less information. Available from Wireshark 2.2.0.
         """
         super(FileCapture, self).__init__(display_filter=display_filter, only_summaries=only_summaries,
                                           decryption_key=decryption_key, encryption_type=encryption_type,
                                           decode_as=decode_as, disable_protocol=disable_protocol, tshark_path=tshark_path,
-                                          override_prefs=override_prefs)
+                                          override_prefs=override_prefs, use_json=use_json)
         self.input_filename = input_file
         if not isinstance(input_file, basestring):
             self.input_filename = input_file.name

--- a/src/pyshark/capture/inmem_capture.py
+++ b/src/pyshark/capture/inmem_capture.py
@@ -20,7 +20,7 @@ class InMemCapture(Capture):
 
     def __init__(self, bpf_filter=None, display_filter=None, only_summaries=False,
                   decryption_key=None, encryption_type='wpa-pwk', decode_as=None,
-                  disable_protocol=None, tshark_path=None, override_prefs=None):
+                  disable_protocol=None, tshark_path=None, override_prefs=None, use_json=False):
         """
         Creates a new in-mem capture, a capture capable of receiving binary packets and parsing them using tshark.
         Currently opens a new instance of tshark for every packet buffer,
@@ -43,7 +43,8 @@ class InMemCapture(Capture):
         super(InMemCapture, self).__init__(display_filter=display_filter, only_summaries=only_summaries,
                                            decryption_key=decryption_key, encryption_type=encryption_type,
                                            decode_as=decode_as, disable_protocol=disable_protocol,
-                                           tshark_path=tshark_path, override_prefs=override_prefs)
+                                           tshark_path=tshark_path, override_prefs=override_prefs,
+                                           use_json=use_json)
         self.bpf_filter = bpf_filter
         self._packets_to_write = None
         self._current_linktype = None

--- a/src/pyshark/capture/live_capture.py
+++ b/src/pyshark/capture/live_capture.py
@@ -6,6 +6,7 @@ import sys
 if sys.version_info >= (3, 0):
     basestring = str
 
+
 class LiveCapture(Capture):
     """
     Represents a live capture on a network interface.
@@ -13,7 +14,7 @@ class LiveCapture(Capture):
 
     def __init__(self, interface=None, bpf_filter=None, display_filter=None, only_summaries=False, decryption_key=None,
                  encryption_type='wpa-pwk', output_file=None, decode_as=None, disable_protocol=None, tshark_path=None,
-                 override_prefs=None, capture_filter=None, monitor_mode=None):
+                 override_prefs=None, capture_filter=None, monitor_mode=None, use_json=False):
         """
         Creates a new live capturer on a given interface. Does not start the actual capture itself.
 
@@ -32,12 +33,14 @@ class LiveCapture(Capture):
         :param override_prefs: A dictionary of tshark preferences to override, {PREFERENCE_NAME: PREFERENCE_VALUE, ...}.
         :param capture_filter: Capture (wireshark) filter to use.
         :param disable_protocol: Tells tshark to remove a dissector for a specifc protocol.
+        :param use_json: Uses tshark in JSON mode (EXPERIMENTAL). It is a good deal faster than XML
+        but also has less information. Available from Wireshark 2.2.0.
         """
         super(LiveCapture, self).__init__(display_filter=display_filter, only_summaries=only_summaries,
                                           decryption_key=decryption_key, encryption_type=encryption_type,
                                           output_file=output_file, decode_as=decode_as, disable_protocol=disable_protocol,
                                           tshark_path=tshark_path, override_prefs=override_prefs,
-                                          capture_filter=capture_filter)
+                                          capture_filter=capture_filter, use_json=use_json)
         self.bpf_filter = bpf_filter
         self.monitor_mode = monitor_mode
 

--- a/src/pyshark/packet/common.py
+++ b/src/pyshark/packet/common.py
@@ -8,3 +8,17 @@ class Pickleable(object):
 
     def __setstate__(self, data):
         self.__dict__.update(data)
+
+
+class SlotsPickleable(object):
+    __slots__ = []
+
+    def __getstate__(self):
+        ret = {}
+        for slot in self.__slots__:
+            ret[slot] = getattr(self, slot)
+        return ret
+
+    def __setstate__(self, data):
+        for key, val in data.iteritems():
+            setattr(self, key, val)

--- a/src/pyshark/packet/fields.py
+++ b/src/pyshark/packet/fields.py
@@ -1,9 +1,9 @@
 import binascii
 
-from pyshark.packet.common import Pickleable
+from pyshark.packet.common import Pickleable, SlotsPickleable
 
 
-class LayerField(object):
+class LayerField(SlotsPickleable):
     """
     Holds all data about a field of a layer, both its actual value and its name and nice representation.
     """
@@ -51,16 +51,6 @@ class LayerField(object):
     def showname_key(self):
         if self.showname and ': ' in self.showname:
             return self.showname.split(': ')[0]
-
-    def __getstate__(self):
-        ret = {}
-        for slot in self.__slots__:
-            ret[slot] = getattr(self, slot)
-        return ret
-
-    def __setstate__(self, data):
-        for key, val in data.iteritems():
-            setattr(self, key, val)
 
     @property
     def binary_value(self):

--- a/src/pyshark/packet/fields.py
+++ b/src/pyshark/packet/fields.py
@@ -1,0 +1,114 @@
+import binascii
+
+from pyshark.packet.common import Pickleable
+
+
+class LayerField(object):
+    """
+    Holds all data about a field of a layer, both its actual value and its name and nice representation.
+    """
+    # Note: We use this object with slots and not just a dict because
+    # it's much more memory-efficient (cuts about a third of the memory).
+    __slots__ = ['name', 'showname', 'raw_value', 'show', 'hide', 'pos', 'size', 'unmaskedvalue']
+
+    def __init__(self, name=None, showname=None, value=None, show=None, hide=None, pos=None, size=None, unmaskedvalue=None):
+        self.name = name
+        self.showname = showname
+        self.raw_value = value
+        self.show = show
+        self.pos = pos
+        self.size = size
+        self.unmaskedvalue = unmaskedvalue
+
+        if hide and hide == 'yes':
+            self.hide = True
+        else:
+            self.hide = False
+
+    def __repr__(self):
+        return '<LayerField %s: %s>' % (self.name, self.get_default_value())
+
+    def get_default_value(self):
+        """
+        Gets the best 'value' string this field has.
+        """
+        val = self.show
+        if not val:
+            val = self.raw_value
+        if not val:
+            val = self.showname
+        return val
+
+    @property
+    def showname_value(self):
+        """
+        For fields which do not contain a normal value, we attempt to take their value from the showname.
+        """
+        if self.showname and ': ' in self.showname:
+            return self.showname.split(': ')[1]
+
+    @property
+    def showname_key(self):
+        if self.showname and ': ' in self.showname:
+            return self.showname.split(': ')[0]
+
+    def __getstate__(self):
+        ret = {}
+        for slot in self.__slots__:
+            ret[slot] = getattr(self, slot)
+        return ret
+
+    def __setstate__(self, data):
+        for key, val in data.iteritems():
+            setattr(self, key, val)
+
+    @property
+    def binary_value(self):
+        """
+        Returns the raw value of this field (as a binary string)
+        """
+        return binascii.unhexlify(self.raw_value)
+
+    @property
+    def int_value(self):
+        """
+        Returns the raw value of this field (as an integer).
+        """
+        return int(self.raw_value, 16)
+
+
+class LayerFieldsContainer(str, Pickleable):
+    """
+    An object which contains one or more fields (of the same name).
+    When accessing member, such as showname, raw_value, etc. the appropriate member of the main (first) field saved
+    in this container will be shown.
+    """
+
+    def __new__(cls, main_field, *args, **kwargs):
+        obj = str.__new__(cls, main_field.get_default_value(), *args, **kwargs)
+        obj.fields = [main_field]
+        return obj
+
+    def add_field(self, field):
+        self.fields.append(field)
+
+    @property
+    def main_field(self):
+        return self.fields[0]
+
+    @property
+    def alternate_fields(self):
+        """
+        Return the alternate values of this field containers (non-main ones).
+        """
+        return self.fields[1:]
+
+    @property
+    def all_fields(self):
+        """
+        Returns all fields in a list, the main field followed by the alternate fields.
+        """
+        return self.fields
+
+    def __getattr__(self, item):
+        return getattr(self.main_field, item)

--- a/src/pyshark/tshark/tshark.py
+++ b/src/pyshark/tshark/tshark.py
@@ -13,6 +13,7 @@ from pyshark.config import get_config
 class TSharkNotFoundException(Exception):
     pass
 
+
 class TSharkVersionException(Exception):
     pass
 
@@ -97,6 +98,7 @@ def get_tshark_path(tshark_path=None):
         'Search these paths: {}'.format(possible_paths)
     )
 
+
 def get_tshark_version(tshark_path=None):
     parameters = [get_tshark_path(tshark_path), '-v']
     version_output = check_output(parameters).decode("ascii")
@@ -109,6 +111,12 @@ def get_tshark_version(tshark_path=None):
 
     return version_string
 
+
+def tshark_supports_json(tshark_path=None):
+    tshark_version = get_tshark_version(tshark_path)
+    return LooseVersion(tshark_version) >= LooseVersion("2.2.0")
+
+
 def get_tshark_display_filter_flag(tshark_path=None):
     """
     Returns '-Y' for tshark versions >= 1.10.0 and '-R' for older versions.
@@ -118,6 +126,7 @@ def get_tshark_display_filter_flag(tshark_path=None):
         return '-Y'
     else:
         return '-R'
+
 
 def get_tshark_interfaces(tshark_path=None):
     """

--- a/src/pyshark/tshark/tshark_json.py
+++ b/src/pyshark/tshark/tshark_json.py
@@ -9,13 +9,16 @@ from pyshark.packet.packet import Packet
 
 def packet_from_json_packet(json_pkt):
     pkt_dict = json.loads(json_pkt)
-    layers = {name: JsonLayer(name, layer)
-              for name, layer in pkt_dict['_source']['layers'].items()}
-    frame = layers.pop('frame')
-    protocol_order = frame.protocols.split(':')
-    layers = [layers[proto] for proto in protocol_order if proto in layers]
+    # We use the frame dict here and not the object access because it's faster.
+    frame_dict = pkt_dict['_source']['layers']['frame']
+    layers = []
+    for layer in frame_dict['frame.protocols'].split(':'):
+        layer_dict = pkt_dict['_source']['layers'].get(layer)
+        if layer_dict is not None:
+            layers.append(JsonLayer(layer, layer_dict))
 
-    return Packet(layers=layers, frame_info=frame, number=int(frame.number),
-                  length=int(frame.len),
-                  sniff_time=frame.time,
-                  interface_captured=frame.interface_id)
+    return Packet(layers=layers, frame_info=JsonLayer('frame', frame_dict),
+                  number=int(frame_dict['frame.number']),
+                  length=int(frame_dict['frame.len']),
+                  sniff_time=frame_dict['frame.time'],
+                  interface_captured=frame_dict['frame.interface_id'])

--- a/src/pyshark/tshark/tshark_json.py
+++ b/src/pyshark/tshark/tshark_json.py
@@ -1,0 +1,21 @@
+try:
+    import ujson as json
+except ImportError:
+    import json
+
+from pyshark.packet.layer import JsonLayer
+from pyshark.packet.packet import Packet
+
+
+def packet_from_json_packet(json_pkt):
+    pkt_dict = json.loads(json_pkt)
+    layers = {name: JsonLayer(name, layer)
+              for name, layer in pkt_dict['_source']['layers'].items()}
+    frame = layers.pop('frame')
+    protocol_order = frame.protocols.split(':')
+    layers = [layers[proto] for proto in protocol_order if proto in layers]
+
+    return Packet(layers=layers, frame_info=frame, number=int(frame.number),
+                  length=int(frame.len),
+                  sniff_time=frame.time,
+                  interface_captured=frame.interface_id)

--- a/src/pyshark/tshark/tshark_xml.py
+++ b/src/pyshark/tshark/tshark_xml.py
@@ -41,18 +41,3 @@ def _packet_from_pdml_packet(pdml_packet):
                   length=geninfo.get_field_value('len'), sniff_time=geninfo.get_field_value('timestamp', raw=True),
                   captured_length=geninfo.get_field_value('caplen'),
                   interface_captured=frame.get_field_value('interface_id', raw=True))
-
-
-
-def packets_from_xml(xml_data):
-    """
-    Returns a list of Packet objects from a TShark XML.
-
-    :param xml_data: str containing the XML.
-    """
-    pdml = lxml.objectify.fromstring(xml_data)
-    packets = []
-
-    for xml_pkt in pdml.getchildren():
-        packets += [packet_from_xml_packet(xml_pkt)]
-    return packets

--- a/src/setup.py
+++ b/src/setup.py
@@ -6,7 +6,7 @@ with open(os.path.join(os.path.dirname(__file__), 'README.txt')) as f:
 
 setup(
     name="pyshark",
-    version="0.3.6.3",
+    version="0.3.7",
     packages=find_packages(),
     package_data={'': ['*.ini', '*.pcapng']},
     # Temporarily using trollis 1.0.4 until issue https://github.com/haypo/trollius/issues/4 is resolved.


### PR DESCRIPTION
This branch adds an experimental capacity to use JSON instead of XML parsing with tshark. This is a feature from Wireshark 2.2.0. It is not the default option.
Please review and make suggestions.

The speed-up is considerable, however multiple things should be noted:

- The JSON does not contain the same amount of information the XML does. The actual value of the field is present but the "nice" value and presentation are not. As such, I recommend it for programmatic use but not for interactive use (where performance is not important anyway).
- Field names may be slightly different, and in particular I use a different nesting for tree fields, which is to say that instead of accessing an inner field in a flat way like `pkt.tcp.flags_ack` you will access it via `pkt.tcp.flags.ack`. 
- Because of those two changes, existing pyshark code is not immediately portable to the JSON version.
- I have not comprehensively tested it, and it is not tested for InMem capture at all. 

Performance (in all tests packets are immediately discarded after parsing):

**Medium pcap (17MB mostly UDP, 20000 packets)**
Pyshark using XML: ~29.2 s
Pyshark using JSON: ~3.49 s
Scapy: ~7.08 s

**Large pcap (133M, ~150000 packets)**
Pyshark using XML: 3 min 43 s
Pyshark using JSON: 25.4 s
Scapy: Crashes :(