### PR TITLE
Update showname_value() to support string with more than one colon.

### DIFF
--- a/src/pyshark/packet/fields.py
+++ b/src/pyshark/packet/fields.py
@@ -45,12 +45,12 @@ class LayerField(SlotsPickleable):
         For fields which do not contain a normal value, we attempt to take their value from the showname.
         """
         if self.showname and ': ' in self.showname:
-            return self.showname.split(': ')[1]
+            return self.showname.split(': ', 1)[1]
 
     @property
     def showname_key(self):
         if self.showname and ': ' in self.showname:
-            return self.showname.split(': ')[0]
+            return self.showname.split(': ', 1)[0]
 
     @property
     def binary_value(self):


### PR DESCRIPTION
Like **'Opcode: ACCESS (3), [Check: RD LU MD XT DL]'**,

`LayerField.showname_value()` will give **'ACCESS (3), [Check'** without `maxsplit=1`.