### PR TITLE
tshark: Suppress stderr when checking tshark version and interfaces

### DIFF
--- a/src/pyshark/tshark/tshark.py
+++ b/src/pyshark/tshark/tshark.py
@@ -42,7 +42,7 @@ def check_output(*popenargs, **kwargs):
     'ls: non_existent_file: No such file or directory\n'
     """
     #if sys.version_info.major > 2 or sys.version_info.minor >= 7:
-    #    return subprocess.check_output(*popenargs, **kwargs) 
+    #    return subprocess.check_output(*popenargs, **kwargs)
 
     if 'stdout' in kwargs:
         raise ValueError('stdout argument not allowed, it will be overridden.')
@@ -101,7 +101,9 @@ def get_tshark_path(tshark_path=None):
 
 def get_tshark_version(tshark_path=None):
     parameters = [get_tshark_path(tshark_path), '-v']
-    version_output = check_output(parameters).decode("ascii")
+    with open(os.devnull, 'w') as null:
+        version_output = check_output(parameters, stderr=null).decode("ascii")
+
     version_line = version_output.splitlines()[0]
     pattern = '.*\s(\d+\.\d+\.\d+).*'  # match " #.#.#" version pattern
     m = re.match(pattern, version_line)
@@ -134,6 +136,7 @@ def get_tshark_interfaces(tshark_path=None):
     internally to capture on multiple interfaces.
     """
     parameters = [get_tshark_path(tshark_path), '-D']
-    tshark_interfaces = check_output(parameters).decode("ascii")
-    
+    with open(os.devnull, 'w') as null:
+        tshark_interfaces = check_output(parameters, stderr=null).decode("ascii")
+
     return [line.split('.')[0] for line in tshark_interfaces.splitlines()]


### PR DESCRIPTION
Not suppressing stderr leads to leaking of the warning/error messages
all the way up to the parent process.