### PR TITLE
add interfaces to dumpcap parameters even in monitor mode

### DIFF
--- a/src/pyshark/capture/live_capture.py
+++ b/src/pyshark/capture/live_capture.py
@@ -75,9 +75,8 @@ class LiveCapture(Capture):
             params += ['-f', self.bpf_filter]
         if self.monitor_mode:
             params += ['-I']
-        else:
-            for interface in self.interfaces:
-                params += ['-i', interface]
+        for interface in self.interfaces:
+            params += ['-i', interface]
         # Write to STDOUT
         params += ["-w", "-"]
         return params

--- a/tests/capture/test_live_capture.py
+++ b/tests/capture/test_live_capture.py
@@ -1,0 +1,18 @@
+import pytest
+import pyshark
+
+@pytest.fixture
+def capture():
+    return pyshark.LiveCapture()
+
+@pytest.mark.parametrize("interfaces", [["wlan0"]])
+@pytest.mark.parametrize("monitoring", [True, False])
+def test_get_dumpcap_interface_parameter(capture, monitoring, interfaces):
+    #type: (pyshark.LiveCapture, bool, list) -> None
+    capture.monitor_mode = monitoring
+    capture.interfaces = interfaces
+    dumpcap_parameters = capture._get_dumpcap_parameters()
+    dumpcap_interfaces = [ dumpcap_parameters[index+1]
+                           for index, value in enumerate(dumpcap_parameters)
+                           if value == "-i" ]
+    assert dumpcap_interfaces == interfaces

--- a/tests/capture/test_live_capture.py
+++ b/tests/capture/test_live_capture.py
@@ -1,18 +1,26 @@
+import mock
 import pytest
+
 import pyshark
 
-@pytest.fixture
-def capture():
-    return pyshark.LiveCapture()
 
-@pytest.mark.parametrize("interfaces", [["wlan0"]])
+@pytest.yield_fixture(params=[["wlan0"], ["wlan0mon", "wlan1mon"]])
+def interfaces(request):
+    with mock.patch("pyshark.tshark.tshark.get_tshark_interfaces", return_value=request.param):
+        yield request.param
+
+
+@pytest.fixture
+def capture(interfaces):
+    return pyshark.LiveCapture(interface=interfaces)
+
+
 @pytest.mark.parametrize("monitoring", [True, False])
 def test_get_dumpcap_interface_parameter(capture, monitoring, interfaces):
-    #type: (pyshark.LiveCapture, bool, list) -> None
+    # type: (pyshark.LiveCapture, bool, list) -> None
     capture.monitor_mode = monitoring
-    capture.interfaces = interfaces
     dumpcap_parameters = capture._get_dumpcap_parameters()
-    dumpcap_interfaces = [ dumpcap_parameters[index+1]
-                           for index, value in enumerate(dumpcap_parameters)
-                           if value == "-i" ]
+    dumpcap_interfaces = [dumpcap_parameters[index + 1]
+                          for index, value in enumerate(dumpcap_parameters)
+                          if value == "-i"]
     assert dumpcap_interfaces == interfaces


### PR DESCRIPTION
Proposed fix for #213 

according to the _get_dumpcap_parameters method of Capture, interfaces are ignored if monitor mode is enabled.
I checked with dumpcap / tshark in version 2.2.6 and it seemed to work quite well.

Just changed the if statement and wrote a simple test for that