### PR TITLE
On LayerFieldsContainer's constructor check if main_field has the def…

### DIFF
--- a/src/pyshark/packet/fields.py
+++ b/src/pyshark/packet/fields.py
@@ -85,10 +85,10 @@ class LayerFieldsContainer(str, Pickleable):
     """
 
     def __new__(cls, main_field, *args, **kwargs):
-        value = main_field.get_default_value()
-        if value is None:
-            value = ''
-        obj = str.__new__(cls, value, *args, **kwargs)
+        if hasattr(main_field, 'get_default_value'):
+            obj = str.__new__(cls, main_field.get_default_value(), *args, **kwargs)
+        else:
+            obj = str.__new__(cls, main_field, *args, **kwargs)
         obj.fields = [main_field]
         return obj
 


### PR DESCRIPTION
…ault_value method

Before this fix, an error would occur when using pickle.loads() on a pickled Packet.

Script to recreate error:
```python
import pyshark
import pickle

cap = pyshark.LiveCapture(interface='wlp6s0')
cap.sniff(packet_count=1)
pickled = pickle.dumps(cap[0])
good = pickle.loads(pickled)
```

> Traceback (most recent call last):
  File "example.py", line 8, in <module>
    good = pickle.loads(pickled)
  File "/home/user/.local/lib/python3.6/site-packages/pyshark/packet/fields.py", line 88, in __new__
    value = main_field.get_default_value()
AttributeError: 'str' object has no attribute 'get_default_value'