### PR TITLE
Pickle/Unpickle of Captured Packets

### DIFF
--- a/src/pyshark/packet/common.py
+++ b/src/pyshark/packet/common.py
@@ -20,5 +20,5 @@ class SlotsPickleable(object):
         return ret
 
     def __setstate__(self, data):
-        for key, val in data.iteritems():
+        for key, val in data.items():
             setattr(self, key, val)

--- a/src/pyshark/packet/fields.py
+++ b/src/pyshark/packet/fields.py
@@ -85,10 +85,10 @@ class LayerFieldsContainer(str, Pickleable):
     """
 
     def __new__(cls, main_field, *args, **kwargs):
-        value = main_field.get_default_value()
-        if value is None:
-            value = ''
-        obj = str.__new__(cls, value, *args, **kwargs)
+        if hasattr(main_field, 'get_default_value'):
+            obj = str.__new__(cls, main_field.get_default_value(), *args, **kwargs)
+        else:
+            obj = str.__new__(cls, main_field, *args, **kwargs)
         obj.fields = [main_field]
         return obj
 


### PR DESCRIPTION
Fixed issue of being unable to unpickle captured packets due to error occuring in overriden __new__ method in LayerFieldsContainer.

Took edits from @alagoa pull request #271 and made edits in common.py for python3 compatibility.
Resolves #63 #169 