### PR TITLE
Windows 10 fix for pyshark

### DIFF
--- a/src/pyshark/capture/live_capture.py
+++ b/src/pyshark/capture/live_capture.py
@@ -71,7 +71,7 @@ class LiveCapture(Capture):
 
     def _get_dumpcap_parameters(self):
         # Don't report packet counts, use pcap format
-        params = ["-q", "-P"]
+        params = ["-q"]
         if self.bpf_filter:
             params += ['-f', self.bpf_filter]
         if self.monitor_mode:


### PR DESCRIPTION
Removing -P option from dumpcap parameters enables packet sniffing on Windows 10. Otherwise there is always 0 packet read.

I was testing change on Win 10, Ubuntu and on OS X. Didn't notice any problems.