### PR TITLE
Handle case when 'hex' string is of odd length (to pad with zeros)

### DIFF
--- a/src/pyshark/packet/fields.py
+++ b/src/pyshark/packet/fields.py
@@ -57,7 +57,11 @@ class LayerField(SlotsPickleable):
         """
         Converts this field to binary (assuming it's a binary string)
         """
-        return binascii.unhexlify(self.raw_value)
+        str_raw_value = str(self.raw_value)
+        if len(str_raw_value) % 2 == 1:
+            str_raw_value = '0' + str_raw_value
+
+        return binascii.unhexlify(str_raw_value)
 
     @property
     def int_value(self):


### PR DESCRIPTION
I have faced a situation when sniffer crashes in case of below TCP Flag value:
`{'size': '2', 'unmaskedvalue': 'a002', 'name': 'tcp.flags', 'value': '2', 'show': '0x00000002', 'pos': '46', 'showname': 'Flags: 0x002 (SYN)'}`

There is a `binascii.unhexlify` call in below function. It requires **hex** string to be of even length.
However, a packet flag has produced odd length string (`'value': '2'` as in above example).

So I have added handling for this case. I have tested it and it seems to work fine.
Could you please accept this fix in main repo?

Thanks,
Paul