### PR TITLE
Fixed bug with bpf filter string contained spaces.

### DIFF
--- a/tests/capture/test_live_capture.py
+++ b/tests/capture/test_live_capture.py
@@ -27,3 +27,11 @@ def test_get_dumpcap_interface_parameter(capture, monitoring, interfaces):
                           for index, value in enumerate(dumpcap_parameters)
                           if value == "-i"]
     assert dumpcap_interfaces == interfaces
+
+
+def test_check_capture_filter_has_quotes(capture):
+    filter_string = "tcp port 80"
+    quoted_filter = '"%s"' % filter_string
+    capture.bpf_filter = filter_string
+    params = capture._get_dumpcap_parameters()
+    assert quoted_filter in params


### PR DESCRIPTION
Now you can pass filters like "tcp port 80" without any troubles.
Command execution function changed from asyncio.create_subprocess_exec to asyncio.create_subprocess_shell