### PR TITLE
Tiny Change to readability to the top level __init__

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,3 +216,6 @@ pip-log.txt
 
 # Pycharm
 .idea/
+
+# kcexn local gitignores
+test_pcaps/

--- a/.gitignore
+++ b/.gitignore
@@ -219,3 +219,6 @@ pip-log.txt
 
 # kcexn local gitignores
 test_pcaps/
+Pipfile
+example_scripts/
+dependencies/

--- a/src/pyshark/__init__.py
+++ b/src/pyshark/__init__.py
@@ -4,11 +4,11 @@ import sys
 class UnsupportedVersionException(Exception):
     pass
 
-
-if sys.version_info[0] < 3 or (sys.version_info[0] == 3 and sys.version_info[1] < 5):
+if sys.hexversion < 0x03050000:
     raise UnsupportedVersionException("Your version of Python is unsupported. "
                                       "Pyshark requires Python >= 3.5 & Wireshark >= 2.2.0. "
                                       " Please upgrade or use pyshark-legacy, or pyshark version 0.3.8")
+
 
 from pyshark.capture.live_capture import LiveCapture
 from pyshark.capture.live_ring_capture import LiveRingCapture


### PR DESCRIPTION
I feel that the use of sys.hexversion here instead of sys.version_info greatly simplifies the version checking expression in the top level __init__, as now there is a singular condition check instead of a compound condition check. Particularly since originally sys.version_info[0] is being checked twice.