### PR TITLE
Changed the FileNotFound error message to line up more closely with t…

### DIFF
--- a/src/pyshark/capture/file_capture.py
+++ b/src/pyshark/capture/file_capture.py
@@ -47,7 +47,10 @@ class FileCapture(Capture):
         if not isinstance(input_file, basestring):
             self.input_filename = input_file.name
         if not os.path.exists(self.input_filename):
-            raise FileNotFoundError(str(self.input_filename))
+            raise FileNotFoundError(
+                    '[Errno 2] No such file or directory: '
+                    + str(self.input_filename)
+                    )
         self.keep_packets = keep_packets
         self._packet_generator = self._packets_from_tshark_sync()
 


### PR DESCRIPTION
An improvement on the error message reporting when a file does not exist or can't be found by FileCapture. This message matches the message given by the built in library open() as part of python's file handling.