### PR TITLE
Using pcapng in dumpcap when tshark>2.5, caching tshark version

### DIFF
--- a/src/pyshark/capture/inmem_capture.py
+++ b/src/pyshark/capture/inmem_capture.py
@@ -81,7 +81,7 @@ class InMemCapture(Capture):
         The latter variable being the number of characters to ignore in order to pass the packet (i.e. extra newlines,
         commas, parenthesis).
         """
-        if LooseVersion(self._tshark_version) >= LooseVersion("3.0.0"):
+        if self._tshark_version >= LooseVersion("3.0.0"):
             return ("%s  }" % os.linesep).encode(), ("}%s]" % os.linesep).encode(), 0
         else:
             return ("}%s%s" % (os.linesep, os.linesep)).encode(), ("}%s%s]" % (os.linesep, os.linesep)).encode(), 1

--- a/src/pyshark/capture/live_capture.py
+++ b/src/pyshark/capture/live_capture.py
@@ -1,6 +1,7 @@
 import os
 
 import asyncio
+from distutils.version import LooseVersion
 
 from pyshark.capture.capture import Capture
 from pyshark.tshark.tshark import get_tshark_interfaces, get_process_path
@@ -71,8 +72,11 @@ class LiveCapture(Capture):
         return params
 
     def _get_dumpcap_parameters(self):
-        # Don't report packet counts, use pcap format
-        params = ["-q", "-P"]
+        # Don't report packet counts.
+        params = ["-q"]
+        if self._get_tshark_version() < LooseVersion("2.5.0"):
+            # Tshark versions older than 2.5 don't support pcapng. This flag forces dumpcap to output pcap.
+            params += ["-P"]
         if self.bpf_filter:
             params += ['-f', self.bpf_filter]
         if self.monitor_mode:

--- a/src/pyshark/tshark/tshark.py
+++ b/src/pyshark/tshark/tshark.py
@@ -74,19 +74,18 @@ def get_tshark_version(tshark_path=None):
         raise TSharkVersionException('Unable to parse TShark version from: {}'.format(version_line))
     version_string = m.groups()[0]  # Use first match found
 
-    return version_string
+    return LooseVersion(version_string)
 
 
 def tshark_supports_json(tshark_version):
-    return LooseVersion(tshark_version) >= LooseVersion("2.2.0")
+    return tshark_version >= LooseVersion("2.2.0")
 
 
-def get_tshark_display_filter_flag(tshark_path=None):
+def get_tshark_display_filter_flag(tshark_version):
     """
     Returns '-Y' for tshark versions >= 1.10.0 and '-R' for older versions.
     """
-    tshark_version = get_tshark_version(tshark_path)
-    if LooseVersion(tshark_version) >= LooseVersion("1.10.0"):
+    if tshark_version >= LooseVersion("1.10.0"):
         return '-Y'
     else:
         return '-R'

--- a/tests/test_tshark.py
+++ b/tests/test_tshark.py
@@ -1,3 +1,5 @@
+from distutils.version import LooseVersion
+
 try:
     import mock
 except ModuleNotFoundError:
@@ -29,17 +31,16 @@ def test_get_tshark_version(mock_check_output):
     expected = '1.12.1'
     assert actual == expected
 
-@mock.patch('pyshark.tshark.tshark.get_tshark_version', autospec=True)
-def test_get_display_filter_flag(mock_get_tshark_version):
-    mock_get_tshark_version.return_value = '1.10.0'
-    actual = get_tshark_display_filter_flag()
+
+def test_get_display_filter_flag():
+    actual = get_tshark_display_filter_flag(LooseVersion('1.10.0'))
     expected = '-Y'
     assert actual == expected
 
-    mock_get_tshark_version.return_value = '1.6.0'
-    actual = get_tshark_display_filter_flag()
+    actual = get_tshark_display_filter_flag(LooseVersion('1.6.0'))
     expected = '-R'
     assert actual == expected
+
 
 @mock.patch('subprocess.check_output', autospec=True)
 def test_get_tshark_interfaces(mock_check_output):


### PR DESCRIPTION
Solves #248 

Wireshark fix: https://code.wireshark.org/review/#/c/24536/ 