### PR TITLE
Added a workaround for Python 3.5 exception on capture eventloop clos…

### DIFF
--- a/src/pyshark/capture/capture.py
+++ b/src/pyshark/capture/capture.py
@@ -426,6 +426,7 @@ class Capture(object):
 
     def close(self):
         self.eventloop.run_until_complete(self._close_async())
+        self.eventloop.close()
 
     async def _close_async(self):
         for process in self._running_processes.copy():

--- a/src/pyshark/capture/file_capture.py
+++ b/src/pyshark/capture/file_capture.py
@@ -86,3 +86,10 @@ class FileCapture(Capture):
             return '<%s %s>' % (self.__class__.__name__, self.input_filename)
         else:
             return '<%s %s (%d packets)>' % (self.__class__.__name__, self.input_filename, len(self._packets))
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, exc_traceback ):
+        self.close()
+


### PR DESCRIPTION
…ing. Also added a context manager to the FileCapture class so that

managing the asyncio eventloop is easier than explicitly calling close at the end of every script. This commit fixes issue #347

I think probably there needs to be a test for the context manager so that opening and closing of files is tested properly. But I'm not sure where you'd like that test to be integrated into? Maybe a new file should be written or a new test class for FileCapture?