### PR TITLE
Fix ResourceWarning by using subprocess' DEVNULL

### DIFF
--- a/src/pyshark/capture/capture.py
+++ b/src/pyshark/capture/capture.py
@@ -367,7 +367,7 @@ class Capture(object):
 
     def _stderr_output(self):
         # Ignore stderr output unless in debug mode (sent to console)
-        return None if self.debug else open(os.devnull, "w")
+        return None if self.debug else subprocess.DEVNULL
 
     def _get_tshark_version(self):
         if self.__tshark_version is None:


### PR DESCRIPTION
Hi, I was tired of being spammed by those resource warnings :
```
ResourceWarning: unclosed file <_io.TextIOWrapper name='/dev/null' mode='w' encoding='UTF-8'>
  stdin=stdin)
ResourceWarning: Enable tracemalloc to get the object allocation traceback
```
So I changed the `open()` call to `DEVNULL` from subprocess. The file descriptor is automatically closed. However this is Python >= 3.3, hope it's ok !
#26 related