### PR TITLE
Fix for output_file when packet_count reached

### DIFF
--- a/src/pyshark/capture/capture.py
+++ b/src/pyshark/capture/capture.py
@@ -128,7 +128,7 @@ class Capture(object):
                 raise StopCapture()
 
         try:
-            self.apply_on_packets(keep_packet, timeout=timeout)
+            self.apply_on_packets(keep_packet, timeout=timeout, packet_count=packet_count)
             self.loaded = True
         except concurrent.futures.TimeoutError:
             pass


### PR DESCRIPTION
This fixes an issue with Live Capture's sniff.  It would always pass packet_count as None to the subprocess.  This meant the subprocess did not correctly finish when packet count was reached and would terminate incorrectly, often resulting in a corrupt or blank output_file.

Timeout is still an issue