### PR TITLE
Fix for the "dictionary changed size during iteration" error when using json with FileCapture

### DIFF
--- a/src/pyshark/packet/layer.py
+++ b/src/pyshark/packet/layer.py
@@ -272,7 +272,7 @@ class JsonLayer(Layer):
         """
         if self._showname_fields_converted_to_regular:
             return
-        for field_name in self._all_fields:
+        for field_name in list(self._all_fields):
             if ":" in field_name:
                 field_value = self._all_fields.pop(field_name)
                 if isinstance(field_value, dict):


### PR DESCRIPTION
This fixes an issue with using JSON in FileCapture. The `_convert_showname_field_names_to_field_names()` function would throw the `dictionary changed size during iteration` error because a key could be popped from the dictionary during the for loop over the dict keys. The solution is to loop over a copy of the keys by wrapping the returned iterator in `list()`.

Fixes KimiNewt/pyshark#420