### PR TITLE
Fixing the sniff timestamp of a packet in the use_json mode

### DIFF
--- a/src/pyshark/tshark/tshark_json.py
+++ b/src/pyshark/tshark/tshark_json.py
@@ -55,5 +55,5 @@ def packet_from_json_packet(json_pkt, deduplicate_fields=True):
     return Packet(layers=layers, frame_info=JsonLayer('frame', frame_dict),
                   number=int(frame_dict.get('frame.number', 0)),
                   length=int(frame_dict['frame.len']),
-                  sniff_time=frame_dict['frame.time'],
+                  sniff_time=frame_dict['frame.time_epoch'],
                   interface_captured=frame_dict.get('frame.interface_id'))


### PR DESCRIPTION
In the default xml mode, pyshark expects Unix time in the 'packet.sniff_timestamp' and date time in the 'packet.sniff_time" (see the 'Packet' class and the 'sniff_time' function of the class for details).
In the json capture, the two types of time were confused, leading to the following error `ValueError: could not convert string to float: Jan XX, 20XX HH:MM:SS` in the `sniff_time` function.

To save the correct timestamp in a packet, the `time_epoch` value of the frame, which represents the Unix time, should be used.