### PR TITLE
Fix wrong get_interfaces implementation

### DIFF
--- a/src/pyshark/tshark/tshark.py
+++ b/src/pyshark/tshark/tshark.py
@@ -101,4 +101,4 @@ def get_tshark_interfaces(tshark_path=None):
     with open(os.devnull, "w") as null:
         tshark_interfaces = subprocess.check_output(parameters, stderr=null).decode("utf-8")
 
-    return [line.split(".")[0] for line in tshark_interfaces.splitlines()]
+    return [line.split(" ")[1] for line in tshark_interfaces.splitlines()]

--- a/src/pyshark/tshark/tshark.py
+++ b/src/pyshark/tshark/tshark.py
@@ -101,4 +101,4 @@ def get_tshark_interfaces(tshark_path=None):
     with open(os.devnull, "w") as null:
         tshark_interfaces = subprocess.check_output(parameters, stderr=null).decode("utf-8")
 
-    return [line.split(" ")[1] for line in tshark_interfaces.splitlines()]
+    return [line.split(" ")[1] for line in tshark_interfaces.splitlines() if not '\\\\.\\' in line]


### PR DESCRIPTION
Output example:
unix:
1. veth44bb9fb
2. veth00863cf
3. eth0
4. veth4ff8cd1
5. veth2ecda2a
6. br-cb423efa22d6
...

Windows:
1. \Device\NPF_{2D2C765C-35AC-4DB6-7KJd-4211E322ED6D} (Local Area Connection* 8)
2. \Device\NPF_{9105521D-80EC-4C2A-95K9-C100FCA7EC8B} (Local Area Connection* 7)
3. \Device\NPF_{AFD838D6-D3D9-47D8-ABE7-B1824198D3EA} (VirtualBox Host-Only Network)
4. \Device\NPF_{94CACD78-2EDD-4F65-8788-354803DF9BD7} (Ethernet 2)
5. \Device\NPF_{D40E026A-BE8F-4490-WYZ7-8CD232CFEC43} (Local Area Connection* 6)
6. \Device\NPF_{A7A2D260-7445-4EB4-840D-F82819AEE871} (Ethernet)
7. \Device\NPF_Loopback (Adapter for loopback traffic capture)
...

Previous implementation returns [1, 2, 3...] instead of list with interface names