### PR TITLE
Timeout error is `asyncio.exceptions.TimeoutError` in python 3.8

### DIFF
--- a/src/pyshark/capture/capture.py
+++ b/src/pyshark/capture/capture.py
@@ -130,7 +130,7 @@ class Capture(object):
         try:
             self.apply_on_packets(keep_packet, timeout=timeout, packet_count=packet_count)
             self.loaded = True
-        except asyncio.exceptions.TimeoutError:
+        except (concurrent.futures.TimeoutError, asyncio.exceptions.TimeoutError):
             pass
 
     def set_debug(self, set_to=True, log_level=logging.DEBUG):
@@ -410,7 +410,7 @@ class Capture(object):
             try:
                 process.kill()
                 return await asyncio.wait_for(process.wait(), 1)
-            except asyncio.exceptions.TimeoutError:
+            except (concurrent.futures.TimeoutError, asyncio.exceptions.TimeoutError):
                 self._log.debug("Waiting for process to close failed, may have zombie process.")
             except ProcessLookupError:
                 pass

--- a/src/pyshark/capture/capture.py
+++ b/src/pyshark/capture/capture.py
@@ -13,6 +13,11 @@ from pyshark.tshark.tshark_json import packet_from_json_packet
 from pyshark.tshark.tshark_xml import packet_from_xml_packet, psml_structure_from_xml
 
 
+if sys.version_info < (3, 8):
+    asyncTimeoutError = concurrent.futures.TimeoutError
+else:
+    asyncTimeoutError = asyncio.exceptions.TimeoutError
+
 class TSharkCrashException(Exception):
     pass
 
@@ -130,7 +135,7 @@ class Capture(object):
         try:
             self.apply_on_packets(keep_packet, timeout=timeout, packet_count=packet_count)
             self.loaded = True
-        except (concurrent.futures.TimeoutError, asyncio.exceptions.TimeoutError):
+        except asyncTimeoutError:
             pass
 
     def set_debug(self, set_to=True, log_level=logging.DEBUG):
@@ -410,7 +415,7 @@ class Capture(object):
             try:
                 process.kill()
                 return await asyncio.wait_for(process.wait(), 1)
-            except (concurrent.futures.TimeoutError, asyncio.exceptions.TimeoutError):
+            except asyncTimeoutError:
                 self._log.debug("Waiting for process to close failed, may have zombie process.")
             except ProcessLookupError:
                 pass

--- a/src/pyshark/capture/capture.py
+++ b/src/pyshark/capture/capture.py
@@ -410,7 +410,7 @@ class Capture(object):
             try:
                 process.kill()
                 return await asyncio.wait_for(process.wait(), 1)
-            except concurrent.futures.TimeoutError:
+            except asyncio.exceptions.TimeoutError:
                 self._log.debug("Waiting for process to close failed, may have zombie process.")
             except ProcessLookupError:
                 pass


### PR DESCRIPTION
The same problem like #402

```
Exception ignored in: <function Capture.__del__ at 0x10a564430>
Traceback (most recent call last):
  File "/usr/local/lib/python3.8/site-packages/pyshark/capture/capture.py", line 436, in __del__
    self.close()
  File "/usr/local/lib/python3.8/site-packages/pyshark/capture/capture.py", line 427, in close
    self.eventloop.run_until_complete(self.close_async())
  File "/usr/local/Cellar/python@3.8/3.8.5/Frameworks/Python.framework/Versions/3.8/lib/python3.8/asyncio/base_events.py", line 616, in run_until_complete
    return future.result()
  File "/usr/local/lib/python3.8/site-packages/pyshark/capture/capture.py", line 431, in close_async
    await self._cleanup_subprocess(process)
  File "/usr/local/lib/python3.8/site-packages/pyshark/capture/capture.py", line 413, in _cleanup_subprocess
    return await asyncio.wait_for(process.wait(), 1)
  File "/usr/local/Cellar/python@3.8/3.8.5/Frameworks/Python.framework/Versions/3.8/lib/python3.8/asyncio/tasks.py", line 490, in wait_for
    raise exceptions.TimeoutError()
asyncio.exceptions.TimeoutError: 
```