### PR TITLE
Better real time packet capture for long time runing

### DIFF
--- a/src/pyshark/capture/capture.py
+++ b/src/pyshark/capture/capture.py
@@ -452,11 +452,6 @@ class Capture(object):
     def get_parameters(self, packet_count=None):
         """Returns the special tshark parameters to be used according to the configuration of this class."""
         params = []
-        if self._capture_filter:
-            params += ["-f", self._capture_filter]
-        if self._display_filter:
-            params += [get_tshark_display_filter_flag(self._get_tshark_version(),),
-                       self._display_filter]
         # Raw is only enabled when JSON is also enabled.
         if self.include_raw:
             params += ["-x"]

--- a/src/pyshark/capture/live_capture.py
+++ b/src/pyshark/capture/live_capture.py
@@ -4,7 +4,7 @@ import sys
 from distutils.version import LooseVersion
 
 from pyshark.capture.capture import Capture
-from pyshark.tshark.tshark import get_tshark_interfaces, get_process_path
+from pyshark.tshark.tshark import get_tshark_interfaces, get_process_path, get_tshark_display_filter_flag
 
 
 class LiveCapture(Capture):
@@ -75,6 +75,11 @@ class LiveCapture(Capture):
             params += ["-f", self.bpf_filter]
         if self.monitor_mode:
             params += ["-I"]
+        if self._capture_filter:
+            params += ["-f", self._capture_filter]
+        if self._display_filter:
+            params += [get_tshark_display_filter_flag(self._get_tshark_version(),),
+                       self._display_filter]
         for interface in self.interfaces:
             params += ["-i", interface]
         # Write to STDOUT

--- a/src/pyshark/capture/live_ring_capture.py
+++ b/src/pyshark/capture/live_ring_capture.py
@@ -6,7 +6,7 @@ class LiveRingCapture(LiveCapture):
     Represents a live ringbuffer capture on a network interface.
     """
 
-    def __init__(self, ring_file_size=1024, num_ring_files=1, ring_file_name='/tmp/pyshark.pcap', interface=None,
+    def __init__(self, ring_file_size=1024, num_ring_files=2, ring_file_name='/tmp/pyshark.pcap', interface=None,
                  bpf_filter=None, display_filter=None, only_summaries=False, decryption_key=None,
                  encryption_type='wpa-pwk', decode_as=None, disable_protocol=None,
                  tshark_path=None, override_prefs=None, include_raw=False, eventloop=None,
@@ -16,6 +16,7 @@ class LiveRingCapture(LiveCapture):
         :param ring_file_size: Size of the ring file in kB, default is 1024
         :param num_ring_files: Number of ring files to keep, default is 1
         :param ring_file_name: Name of the ring file, default is /tmp/pyshark.pcap
+                               Windows users shall define path for Windows
         :param interface: Name of the interface to sniff on or a list of names (str). If not given, runs on all interfaces.
         :param bpf_filter: BPF filter to use on packets.
         :param display_filter: Display (wireshark) filter to use.


### PR DESCRIPTION
This change will allow
1. Use real time live capture
2. tshark creates temporary files. This will allow to use small file size and small number of files.
3. Use capture/display filter