### PR TITLE
Use configparser in config.py (work better with pyinstaller)

### DIFF
--- a/src/pyshark/config.py
+++ b/src/pyshark/config.py
@@ -1,6 +1,6 @@
 import os
 
-import py
+from configparser import ConfigParser
 
 import pyshark
 
@@ -8,4 +8,6 @@ CONFIG_PATH = os.path.join(os.path.dirname(pyshark.__file__), 'config.ini')
 
 
 def get_config():
-    return py.iniconfig.IniConfig(CONFIG_PATH)
+    config = ConfigParser()
+    config.read(CONFIG_PATH)
+    return config


### PR DESCRIPTION
This PR replaces py.iniconfig with the standard library configparser.

There are two benefits

1) Make pyshark work better with pyinstaller, so a fix for issue #245 which was caused by py
2) py library is in maintenance mode since October 2017 and it not intended to be used for new projects (see https://pypi.org/project/py/). The latest python version officially supported by py is 3.7.

This PR allows pyshark to work in an exe created by pyinstaller which was caused by issues with the py library.

The py library is still used for the TerminalWriter in pretty_print so it's not removed completely by this PR, so if an application uses that functionality they would still have issues with pyinstaller. But this PR will fix it for most use cases.