### PR TITLE
Fix for handling invalid output by tshark.

### DIFF
--- a/src/pyshark/tshark/tshark_xml.py
+++ b/src/pyshark/tshark/tshark_xml.py
@@ -6,9 +6,9 @@ from pyshark.packet.packet import Packet
 from pyshark.packet.packet_summary import PacketSummary
 
 # Prepare dictionary used with str.translate for removing invalid XML characters
-DEL_BAD_XML_CHARS = { c: None for c in range(0x00, 0x20) if not c in (0x09, 0x0a, 0x0d) }
-DEL_BAD_XML_CHARS.update({ c: None for c in range(0xd800, 0xe000) })
-DEL_BAD_XML_CHARS.update({ c: None for c in range(0xfffe, 0x10000) })
+DEL_BAD_XML_CHARS = {bad_char: None for bad_char in range(0x00, 0x20) if not bad_char in (0x09, 0x0a, 0x0d)}
+DEL_BAD_XML_CHARS.update({bad_char: None for bad_char in range(0xd800, 0xe000)})
+DEL_BAD_XML_CHARS.update({bad_char: None for bad_char in range(0xfffe, 0x10000)})
 
 def psml_structure_from_xml(psml_structure):
     if not isinstance(psml_structure, lxml.objectify.ObjectifiedElement):

--- a/src/pyshark/tshark/tshark_xml.py
+++ b/src/pyshark/tshark/tshark_xml.py
@@ -23,6 +23,7 @@ def packet_from_xml_packet(xml_pkt, psml_structure=None):
     """
     if not isinstance(xml_pkt, lxml.objectify.ObjectifiedElement):
         parser = lxml.objectify.makeparser(huge_tree=True, recover=True)
+        xml_pkt = xml_pkt.decode(errors='ignore')
         xml_pkt = lxml.objectify.fromstring(xml_pkt, parser)
     if psml_structure:
         return _packet_from_psml_packet(xml_pkt, psml_structure)

--- a/src/pyshark/tshark/tshark_xml.py
+++ b/src/pyshark/tshark/tshark_xml.py
@@ -5,6 +5,10 @@ from pyshark.packet.layer import Layer
 from pyshark.packet.packet import Packet
 from pyshark.packet.packet_summary import PacketSummary
 
+# Prepare dictionary used with str.translate for removing invalid XML characters
+DEL_BAD_XML_CHARS = { c: None for c in range(0x00, 0x20) if not c in (0x09, 0x0a, 0x0d) }
+DEL_BAD_XML_CHARS.update({ c: None for c in range(0xd800, 0xe000) })
+DEL_BAD_XML_CHARS.update({ c: None for c in range(0xfffe, 0x10000) })
 
 def psml_structure_from_xml(psml_structure):
     if not isinstance(psml_structure, lxml.objectify.ObjectifiedElement):
@@ -23,7 +27,7 @@ def packet_from_xml_packet(xml_pkt, psml_structure=None):
     """
     if not isinstance(xml_pkt, lxml.objectify.ObjectifiedElement):
         parser = lxml.objectify.makeparser(huge_tree=True, recover=True)
-        xml_pkt = xml_pkt.decode(errors='ignore')
+        xml_pkt = xml_pkt.decode(errors='ignore').translate(DEL_BAD_XML_CHARS)
         xml_pkt = lxml.objectify.fromstring(xml_pkt, parser)
     if psml_structure:
         return _packet_from_psml_packet(xml_pkt, psml_structure)


### PR DESCRIPTION
There are multiple problems when pyshark receives invalid output from tshark. 

The first problem is when invalid UTF-8 encodings are present in the tshark output. These make pyshark terminate with an XMLSyntaxError exception. The problem was first mentioned five years ago and several duplicate bug reports were filed over the years:
- Issue #116
- Issue #454
- Issue #470 

The second problem is when the tshark output contains invalid XML characters, such as control characters with codes below ASCII 32. These are silently handled by the XML parser running in recovery mode, but not in a satisfying way. When an invalid character is present in an element attribute, the remaining attributes are skipped, which leads to fields being silently lost.

The proposed fix for the UTF-8 encoding problem is to decode the tshark output from UTF-8, with errors ignored, before sending the data to the XML parser. This should be the correct way to handle the tshark input. Quote from the tshark man page:
"TShark uses UTF-8 to represent strings internally. In some cases the output might not be valid. For example, a dissector might generate invalid UTF-8 character sequences. Programs reading TShark output should expect UTF-8 and be prepared for invalid output."

The proposed fix for the invalid XML characters problem is to remove such characters before sending the data to the XML parser.