### PR TITLE
Python 3.10 and Python 3.9 compatibility; disutils deprecation; asyncio method deprecation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
-dist: bionic 
+dist: bionic
 language: python
 python:
   - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.10"
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y tshark

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
   - "3.10"
 before_install:
   - sudo apt-get update -qq

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ py
 pytest
 mock
 lxml
+packaging

--- a/src/pyshark/capture/__init__.py
+++ b/src/pyshark/capture/__init__.py
@@ -1,0 +1,2 @@
+import nest_asyncio
+nest_asyncio.apply()

--- a/src/pyshark/capture/__init__.py
+++ b/src/pyshark/capture/__init__.py
@@ -1,2 +1,0 @@
-import nest_asyncio
-nest_asyncio.apply()

--- a/src/pyshark/capture/capture.py
+++ b/src/pyshark/capture/capture.py
@@ -153,7 +153,7 @@ class Capture(object):
             self.eventloop = asyncio.ProactorEventLoop()
         else:
             try:
-                self.eventloop = asyncio.get_event_loop()
+                self.eventloop = asyncio.get_event_loop_policy().get_event_loop()
             except RuntimeError:
                 if threading.current_thread() != threading.main_thread():
                     # Ran not in main thread, make a new eventloop

--- a/src/pyshark/capture/capture.py
+++ b/src/pyshark/capture/capture.py
@@ -447,7 +447,10 @@ class Capture(object):
                                            % process.returncode)
 
     def close(self):
-        self.eventloop.run_until_complete(self.close_async())
+        if sys.version_info >= (3, 7):
+            self.eventloop.create_task(self.close_async())
+        else:
+            self.eventloop.ensure_future(self.close_async())
 
     async def close_async(self):
         for process in self._running_processes.copy():

--- a/src/pyshark/capture/capture.py
+++ b/src/pyshark/capture/capture.py
@@ -447,10 +447,7 @@ class Capture(object):
                                            % process.returncode)
 
     def close(self):
-        if sys.version_info >= (3, 7):
-            self.eventloop.create_task(self.close_async())
-        else:
-            self.eventloop.ensure_future(self.close_async())
+        self.eventloop.create_task(self.close_async())
 
     async def close_async(self):
         for process in self._running_processes.copy():

--- a/src/pyshark/capture/capture.py
+++ b/src/pyshark/capture/capture.py
@@ -5,7 +5,7 @@ import subprocess
 import concurrent.futures
 import sys
 import logging
-from distutils.version import LooseVersion
+from packaging import version
 
 from pyshark.tshark.tshark import get_process_path, get_tshark_display_filter_flag, \
     tshark_supports_json, TSharkVersionException, get_tshark_version, tshark_supports_duplicate_keys
@@ -33,7 +33,6 @@ class RawMustUseJsonException(Exception):
 class StopCapture(Exception):
     """Exception that the user can throw anywhere in packet-handling to stop the capture process."""
     pass
-
 
 class Capture(object):
     """Base class for packet captures."""
@@ -172,7 +171,7 @@ class Capture(object):
         The latter variable being the number of characters to ignore in order to pass the packet (i.e. extra newlines,
         commas, parenthesis).
         """
-        if self._get_tshark_version() >= LooseVersion("3.0.0"):
+        if self._get_tshark_version() >= version.parse("3.0.0"):
             return ("%s  },%s" % (os.linesep, os.linesep)).encode(), ("}%s]" % os.linesep).encode(), (
                     1 + len(os.linesep))
         else:

--- a/src/pyshark/capture/inmem_capture.py
+++ b/src/pyshark/capture/inmem_capture.py
@@ -59,7 +59,8 @@ class InMemCapture(Capture):
 
     def get_parameters(self, packet_count=None):
         """Returns the special tshark parameters to be used according to the configuration of this class."""
-        params = super(InMemCapture, self).get_parameters(packet_count=packet_count)
+        params = super(InMemCapture, self).get_parameters(
+            packet_count=packet_count)
         params += ['-i', '-']
         return params
 
@@ -70,7 +71,8 @@ class InMemCapture(Capture):
         self._current_tshark = proc
 
         # Create PCAP header
-        header = struct.pack("IHHIIII", 0xa1b2c3d4, 2, 4, 0, 0, 0x7fff, self._current_linktype)
+        header = struct.pack("IHHIIII", 0xa1b2c3d4, 2, 4,
+                             0, 0, 0x7fff, self._current_linktype)
         proc.stdin.write(header)
 
         return proc
@@ -97,7 +99,8 @@ class InMemCapture(Capture):
         secs = int(now)
         usecs = int((now * 1000000) % 1000000)
         # Write packet header
-        self._current_tshark.stdin.write(struct.pack("IIII", secs, usecs, len(packet), len(packet)))
+        self._current_tshark.stdin.write(struct.pack(
+            "IIII", secs, usecs, len(packet), len(packet)))
         self._current_tshark.stdin.write(packet)
 
     def parse_packet(self, binary_packet, sniff_time=None, timeout=DEFAULT_TIMEOUT):
@@ -117,6 +120,8 @@ class InMemCapture(Capture):
         DOES NOT CLOSE tshark. It must be closed manually by calling close() when you're done
         working with it.
         """
+        if self.eventloop is not None:
+            return self.eventloop.run_until_complete(self.parse_packets_async(binary_packets, sniff_times, timeout))
         return asyncio.get_event_loop_policy().get_event_loop().run_until_complete(self.parse_packets_async(binary_packets, sniff_times, timeout))
 
     async def parse_packets_async(self, binary_packets, sniff_times=None, timeout=DEFAULT_TIMEOUT):
@@ -170,7 +175,8 @@ class InMemCapture(Capture):
         By default, assumes the packet is an ethernet packet. For another link type, supply the linktype argument (most
         can be found in the class LinkTypes)
         """
-        warnings.warn("Deprecated method. Use InMemCapture.parse_packet() instead.")
+        warnings.warn(
+            "Deprecated method. Use InMemCapture.parse_packet() instead.")
         self._current_linktype = linktype
         pkt = self.parse_packet(binary_packet, timeout=timeout)
         self.close()

--- a/src/pyshark/capture/inmem_capture.py
+++ b/src/pyshark/capture/inmem_capture.py
@@ -120,9 +120,9 @@ class InMemCapture(Capture):
         DOES NOT CLOSE tshark. It must be closed manually by calling close() when you're done
         working with it.
         """
-        if self.eventloop is not None:
-            return self.eventloop.run_until_complete(self.parse_packets_async(binary_packets, sniff_times, timeout))
-        return asyncio.get_event_loop_policy().get_event_loop().run_until_complete(self.parse_packets_async(binary_packets, sniff_times, timeout))
+        if self.eventloop is None:
+            self._setup_eventloop()
+        return self.eventloop.run_until_complete(self.parse_packets_async(binary_packets, sniff_times, timeout))
 
     async def parse_packets_async(self, binary_packets, sniff_times=None, timeout=DEFAULT_TIMEOUT):
         """A coroutine which parses binary packets and return a list of parsed packets.

--- a/src/pyshark/capture/inmem_capture.py
+++ b/src/pyshark/capture/inmem_capture.py
@@ -6,7 +6,7 @@ import os
 import struct
 import time
 import warnings
-from distutils.version import LooseVersion
+from packaging import version
 
 from pyshark.capture.capture import Capture, StopCapture
 
@@ -82,7 +82,7 @@ class InMemCapture(Capture):
         The latter variable being the number of characters to ignore in order to pass the packet (i.e. extra newlines,
         commas, parenthesis).
         """
-        if self._get_tshark_version() >= LooseVersion("2.6.7"):
+        if self._get_tshark_version() >= version.parse("2.6.7"):
             return ("%s  }" % os.linesep).encode(), ("}%s]" % os.linesep).encode(), 0
         else:
             return ("}%s%s" % (os.linesep, os.linesep)).encode(), ("}%s%s]" % (os.linesep, os.linesep)).encode(), 1

--- a/src/pyshark/capture/inmem_capture.py
+++ b/src/pyshark/capture/inmem_capture.py
@@ -117,7 +117,7 @@ class InMemCapture(Capture):
         DOES NOT CLOSE tshark. It must be closed manually by calling close() when you're done
         working with it.
         """
-        return asyncio.get_event_loop().run_until_complete(self.parse_packets_async(binary_packets, sniff_times, timeout))
+        return asyncio.get_event_loop_policy().get_event_loop().run_until_complete(self.parse_packets_async(binary_packets, sniff_times, timeout))
 
     async def parse_packets_async(self, binary_packets, sniff_times=None, timeout=DEFAULT_TIMEOUT):
         """A coroutine which parses binary packets and return a list of parsed packets.

--- a/src/pyshark/capture/live_capture.py
+++ b/src/pyshark/capture/live_capture.py
@@ -1,7 +1,7 @@
 import os
 import asyncio
 import sys
-from distutils.version import LooseVersion
+from packaging import version
 
 from pyshark.capture.capture import Capture
 from pyshark.tshark.tshark import get_tshark_interfaces, get_process_path
@@ -68,7 +68,7 @@ class LiveCapture(Capture):
     def _get_dumpcap_parameters(self):
         # Don't report packet counts.
         params = ["-q"]
-        if self._get_tshark_version() < LooseVersion("2.5.0"):
+        if self._get_tshark_version() < version.parse("2.5.0"):
             # Tshark versions older than 2.5 don't support pcapng. This flag forces dumpcap to output pcap.
             params += ["-P"]
         if self.bpf_filter:

--- a/src/pyshark/tshark/tshark.py
+++ b/src/pyshark/tshark/tshark.py
@@ -1,5 +1,5 @@
 """Module used for the actual running of TShark"""
-from distutils.version import LooseVersion
+from packaging import version
 import os
 import subprocess
 import sys
@@ -73,20 +73,20 @@ def get_tshark_version(tshark_path=None):
         raise TSharkVersionException("Unable to parse TShark version from: {}".format(version_line))
     version_string = m.groups()[0]  # Use first match found
 
-    return LooseVersion(version_string)
+    return version.parse(version_string)
 
 
 def tshark_supports_duplicate_keys(tshark_version):
-    return tshark_version >= LooseVersion("2.6.7")
+    return tshark_version >= version.parse("2.6.7")
 
 
 def tshark_supports_json(tshark_version):
-    return tshark_version >= LooseVersion("2.2.0")
+    return tshark_version >= version.parse("2.2.0")
 
 
 def get_tshark_display_filter_flag(tshark_version):
     """Returns '-Y' for tshark versions >= 1.10.0 and '-R' for older versions."""
-    if tshark_version >= LooseVersion("1.10.0"):
+    if tshark_version >= version.parse("1.10.0"):
         return "-Y"
     else:
         return "-R"

--- a/src/setup.py
+++ b/src/setup.py
@@ -9,7 +9,7 @@ setup(
     version="0.4.3",
     packages=find_packages(),
     package_data={'': ['*.ini', '*.pcapng']},
-    install_requires=['lxml', 'py'],
+    install_requires=['lxml', 'py', 'packaging'],
     tests_require=['pytest'],
     url="https://github.com/KimiNewt/pyshark",
     license="MIT",

--- a/src/setup.py
+++ b/src/setup.py
@@ -24,5 +24,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 )

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -1,0 +1,11 @@
+[tox]
+envlist = py{35,36,37,38,310}
+
+[testenv]
+deps = 
+    py
+    pytest
+    mock
+    lxml
+    packaging
+commands = pytest .. -s

--- a/src/tox.ini
+++ b/src/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37,38,310}
+envlist = py{35,36,37,38,39,310}
 
 [testenv]
 deps = 

--- a/tests/capture/test_inmem_capture.py
+++ b/tests/capture/test_inmem_capture.py
@@ -29,7 +29,7 @@ def test_can_read_multiple_binary_packet(inmem_capture):
         assert pkt.eth.src == 'aa:bb:cc:dd:ee:f' + str(i + 1)
 
 def test_fed_packets_are_added_to_the_list(inmem_capture):
-    inmem_capture.feed_packet(arp_packet())
+    inmem_capture.feed_packets([arp_packet()])
     assert len(inmem_capture) == 1
 
     inmem_capture.feed_packets([arp_packet(), arp_packet()])

--- a/tests/capture/test_inmem_capture.py
+++ b/tests/capture/test_inmem_capture.py
@@ -18,6 +18,7 @@ def arp_packet(last_byte='f'):
 
 def test_can_read_binary_packet(inmem_capture):
     pkt = inmem_capture.parse_packet(arp_packet('f'))
+    inmem_capture.close()
     assert pkt.eth.src == 'aa:bb:cc:dd:ee:ff'
 
 

--- a/tests/capture/test_inmem_capture.py
+++ b/tests/capture/test_inmem_capture.py
@@ -17,7 +17,7 @@ def arp_packet(last_byte='f'):
 
 
 def test_can_read_binary_packet(inmem_capture):
-    pkt = inmem_capture.feed_packet(arp_packet('f'))
+    pkt = inmem_capture.parse_packet(arp_packet('f'))
     assert pkt.eth.src == 'aa:bb:cc:dd:ee:ff'
 
 

--- a/tests/capture/test_live_capture.py
+++ b/tests/capture/test_live_capture.py
@@ -7,7 +7,7 @@ import pytest
 import pyshark
 
 
-@pytest.yield_fixture(params=[["wlan0"], ["wlan0mon", "wlan1mon"]])
+@pytest.fixture(params=[["wlan0"], ["wlan0mon", "wlan1mon"]])
 def interfaces(request):
     with mock.patch("pyshark.tshark.tshark.get_tshark_interfaces", return_value=request.param):
         yield request.param

--- a/tests/test_cap_operations.py
+++ b/tests/test_cap_operations.py
@@ -54,18 +54,17 @@ def test_getting_packet_summary(simple_summary_capture):
     assert simple_summary_capture[0]._fields
 
 
-
 def _iterate_capture_object(cap_obj, q):
     for packet in cap_obj:
         pass
     q.put(True)
 
 
-@pytest.mark.skip(reason="Don't know how to fix")
 def test_iterate_empty_psml_capture(simple_summary_capture):
-    # simple_summary_capture.display_filter = "frame.len == 1"
+    simple_summary_capture.display_filter = "frame.len == 1"
     q = Queue()
-    p = Process(target=_iterate_capture_object, args=(simple_summary_capture, q))
+    p = Process(target=_iterate_capture_object,
+                args=(simple_summary_capture, q))
     p.start()
     p.join(2)
     try:
@@ -74,4 +73,4 @@ def test_iterate_empty_psml_capture(simple_summary_capture):
         no_hang = False
     if p.is_alive():
         p.terminate()
-    assert no_hang # False here
+    assert no_hang  # False here

--- a/tests/test_tshark.py
+++ b/tests/test_tshark.py
@@ -1,4 +1,4 @@
-from distutils.version import LooseVersion
+from packaging import version
 
 try:
     import mock
@@ -28,16 +28,16 @@ def test_get_tshark_version(mock_check_output):
         b'1998-2014 Gerald Combs <gerald@wireshark.org> and contributors.\n'
     )
     actual = get_tshark_version()
-    expected = '1.12.1'
+    expected = version.parse('1.12.1')
     assert actual == expected
 
 
 def test_get_display_filter_flag():
-    actual = get_tshark_display_filter_flag(LooseVersion('1.10.0'))
+    actual = get_tshark_display_filter_flag(version.parse('1.10.0'))
     expected = '-Y'
     assert actual == expected
 
-    actual = get_tshark_display_filter_flag(LooseVersion('1.6.0'))
+    actual = get_tshark_display_filter_flag(version.parse('1.6.0'))
     expected = '-R'
     assert actual == expected
 


### PR DESCRIPTION
I **replaced the distutils package with the packaging package**, cause distutils is deprecated and will be removed in Python 3.12. The recommended replacement is setuptools which uses packaging. For pyshark only the ability to compare versions is needed. This functionality is provided by packaging. To keep dependencies slim, I choose packaging over setuptools.

asyncio get_event_loop method is also deprecated in Python 3.10 [see](https://docs.python.org/3/library/asyncio-eventloop.html). After fiddling around with nested_asyncio, I realized that nested_asyncio also uses the deprecated get_event_loop method, so I dumped nested_asyncio and **fixed the deprecation warning for the get_event_loop method with "nativ" asyncio methods**.

I also made some small changes to tests in order to prevent pytest and pyshark deprecation warnings.

Finally I placed a "tox.ini" file next to setup.py in src. tox is a command line tool for python testing. It manages generic    virtualenvs and therefore allows to run test with multiple (installed) python versions consecutively.
Install tox:
```
pip3 install tox
```
Run tox:
```
cd pyshark/src
tox
```
The artifacts tox creates are already mentioned in .gitignore.
