### PR TITLE
Removed restriction for win32 users not allowed to sniff using monito…

### DIFF
--- a/src/pyshark/capture/live_capture.py
+++ b/src/pyshark/capture/live_capture.py
@@ -46,9 +46,6 @@ class LiveCapture(Capture):
         self.bpf_filter = bpf_filter
         self.monitor_mode = monitor_mode
 
-        if sys.platform == "win32" and monitor_mode:
-            raise WindowsError("Monitor mode is not supported by the Windows platform")
-
         if interface is None:
             self.interfaces = get_tshark_interfaces(tshark_path)
         elif isinstance(interface, str):


### PR DESCRIPTION
Solves #530 

Removes a seemingly unnecessary prevention for users on win32 systems to enable monitor mode on live capture.