### PR TITLE
Fix path when user provides `tshark_path` using `LiveCapture`.

### DIFF
--- a/src/pyshark/tshark/tshark.py
+++ b/src/pyshark/tshark/tshark.py
@@ -33,7 +33,9 @@ def get_process_path(tshark_path=None, process_name="tshark"):
 
     # Add the user provided path to the search list
     if tshark_path is not None:
-        possible_paths.insert(0, tshark_path)
+        user_tshark_path = os.path.join(os.path.dirname(tshark_path),
+                                        "%s.exe" % process_name if sys.platform.startswith("win") else process_name)
+        possible_paths.insert(0, user_tshark_path)
 
     # Windows search order: configuration file"s path, common paths.
     if sys.platform.startswith("win"):


### PR DESCRIPTION
When I provided a `tshark_path` parameter like `D:\\Program Files\\Wireshark\\tshark.exe`, using `LiveCapture` called tshark in Dumpcap subprocess, and nothing captured.

![图片](https://user-images.githubusercontent.com/41962043/177053089-cf67f288-f821-43b6-847d-844b71e54f14.png)
 
Therefore I tried to run it on a Linux machine which tshark was in the default path, the program captured successfully.
And you can see that the program in Dumpcap subprocess is `dumpcap`.

![图片](https://user-images.githubusercontent.com/41962043/177053221-549e12d3-194d-47b1-97f5-85f3cf04dbb5.png)

After carefully reviewing the source code, I find that when user provides his own `tshark_path`, the `process_name` will not be  spliced to `path`, which is the bug of this problem.

The commit https://github.com/KimiNewt/pyshark/commit/85adafac86c13d90d88d31876ff49c6deae57257 did not solve this bug, so in this PR I try to fix it. 

A user can provide a path like `D:\\Program Files\\Wireshark\\tshark.exe` or `D:\\Program Files\\Wireshark`, and `process_name` will be joined. It is also feasible for Linux.
