### PR TITLE
Add some params for LiveRingCapture.

### DIFF
--- a/src/pyshark/capture/live_ring_capture.py
+++ b/src/pyshark/capture/live_ring_capture.py
@@ -7,7 +7,8 @@ class LiveRingCapture(LiveCapture):
     def __init__(self, ring_file_size=1024, num_ring_files=1, ring_file_name='/tmp/pyshark.pcap', interface=None,
                  bpf_filter=None, display_filter=None, only_summaries=False, decryption_key=None,
                  encryption_type='wpa-pwk', decode_as=None, disable_protocol=None,
-                 tshark_path=None, override_prefs=None, include_raw=False, eventloop=None,
+                 tshark_path=None, override_prefs=None, capture_filter=None, 
+                 use_json=False, use_ek=False, include_raw=False, eventloop=None, 
                  custom_parameters=None, debug=False):
         """
         Creates a new live capturer on a given interface. Does not start the actual capture itself.
@@ -26,14 +27,18 @@ class LiveRingCapture(LiveCapture):
         it attempt to decode any port 8888 traffic as HTTP. See tshark documentation for details.
         :param tshark_path: Path of the tshark binary
         :param override_prefs: A dictionary of tshark preferences to override, {PREFERENCE_NAME: PREFERENCE_VALUE, ...}.
+        :param capture_filter: Capture (wireshark) filter to use.
         :param disable_protocol: Tells tshark to remove a dissector for a specifc protocol.
+        :param use_ek: Uses tshark in EK JSON mode. It is faster than XML but has slightly less data.
+        :param use_json: DEPRECATED. Use use_ek instead.
         :param custom_parameters:  A dict of custom parameters to pass to tshark, i.e. {"--param": "value"}
         or else a list of parameters in the format ["--foo", "bar", "--baz", "foo"]. or else a list of parameters in the format ["--foo", "bar", "--baz", "foo"].
         """
         super(LiveRingCapture, self).__init__(interface, bpf_filter=bpf_filter, display_filter=display_filter, only_summaries=only_summaries,
                                               decryption_key=decryption_key, encryption_type=encryption_type,
                                               tshark_path=tshark_path, decode_as=decode_as, disable_protocol=disable_protocol,
-                                              override_prefs=override_prefs, include_raw=include_raw, eventloop=eventloop,
+                                              override_prefs=override_prefs, capture_filter=capture_filter, 
+                                              use_json=False, use_ek=False, include_raw=include_raw, eventloop=eventloop,
                                               custom_parameters=custom_parameters, debug=debug)
 
         self.ring_file_size = ring_file_size


### PR DESCRIPTION
When a user use `LiveRingCapture` with `include_raw=True`, it will return `use_json must be True if include_raw`. However, `LiveRingCapture` doesn't have `use_json` parameter. 

In the source code, I find that `LiveRingCapture` derives from `LiveCapture` but it doesn't provide the proper parameters to be passed to its parent class.

So I add some parameters for `LiveRingCapture` to solve this problem.