### PR TITLE
Fix some tshark_path problems.

### DIFF
--- a/src/pyshark/config.py
+++ b/src/pyshark/config.py
@@ -1,18 +1,18 @@
-import os
+from pathlib import Path
 
 from configparser import ConfigParser
 
 import pyshark
 
 
-fp_config_path = os.path.join(os.getcwd(), 'config.ini')  # get config from the current directory
-pyshark_config_path = os.path.join(os.path.dirname(pyshark.__file__), 'config.ini')
+fp_config_path = Path.cwd() / 'config.ini'  # get config from the current directory
+pyshark_config_path = Path(pyshark.__file__).parent / 'config.ini'
 
 
 def get_config():
-    if os.path.exists(fp_config_path):
+    if Path.exists(fp_config_path):
         config_path = fp_config_path
-    elif os.path.exists(pyshark_config_path):
+    elif Path.exists(pyshark_config_path):
         config_path = pyshark_config_path
     else:
         return None

--- a/src/pyshark/config.py
+++ b/src/pyshark/config.py
@@ -10,9 +10,9 @@ pyshark_config_path = Path(pyshark.__file__).parent / 'config.ini'
 
 
 def get_config():
-    if Path.exists(fp_config_path):
+    if fp_config_path.exists():
         config_path = fp_config_path
-    elif Path.exists(pyshark_config_path):
+    elif pyshark_config_path.exists():
         config_path = pyshark_config_path
     else:
         return None

--- a/src/pyshark/config.py
+++ b/src/pyshark/config.py
@@ -4,10 +4,19 @@ from configparser import ConfigParser
 
 import pyshark
 
-CONFIG_PATH = os.path.join(os.path.dirname(pyshark.__file__), 'config.ini')
+
+fp_config_path = os.path.join(os.getcwd(), 'config.ini')  # get config from the current directory
+pyshark_config_path = os.path.join(os.path.dirname(pyshark.__file__), 'config.ini')
 
 
 def get_config():
+    if os.path.exists(fp_config_path):
+        CONFIG_PATH = fp_config_path
+    elif os.path.exists(pyshark_config_path):
+        CONFIG_PATH = pyshark_config_path
+    else:
+        return None
+        
     config = ConfigParser()
     config.read(CONFIG_PATH)
     return config

--- a/src/pyshark/config.py
+++ b/src/pyshark/config.py
@@ -11,12 +11,12 @@ pyshark_config_path = os.path.join(os.path.dirname(pyshark.__file__), 'config.in
 
 def get_config():
     if os.path.exists(fp_config_path):
-        CONFIG_PATH = fp_config_path
+        config_path = fp_config_path
     elif os.path.exists(pyshark_config_path):
-        CONFIG_PATH = pyshark_config_path
+        config_path = pyshark_config_path
     else:
         return None
         
     config = ConfigParser()
-    config.read(CONFIG_PATH)
+    config.read(config_path)
     return config

--- a/src/pyshark/tshark/tshark.py
+++ b/src/pyshark/tshark/tshark.py
@@ -28,8 +28,11 @@ def get_process_path(tshark_path=None, process_name="tshark"):
     :param tshark_path: Path of the tshark binary
     :raises TSharkNotFoundException in case TShark is not found in any location.
     """
+    possible_paths = []
+    # Check if `config.ini` exists in the current directory or the pyshark directory
     config = get_config()
-    possible_paths = [config.get(process_name, "%s_path" % process_name)]
+    if config:
+        possible_paths.append(config.get(process_name, "%s_path" % process_name))
 
     # Add the user provided path to the search list
     if tshark_path is not None:


### PR DESCRIPTION
Get `config.ini` from the current directory first, then the pyshark module directory.
Check if the file exists before reading it.

In the `src/pyshark/tshark/tshark.py`, also check if `config.ini` exists before adding it to `possible_paths`.

**The priority that tshark_path loads will be:**
user provided `tshark_path` > `config.ini` in the current directory > `config.ini` in the pyshark module directory > system env

This PR will fix the issue https://github.com/KimiNewt/pyshark/issues/564 .