### PR TITLE
Accepting rpcap:// as a valid interface name

### DIFF
--- a/src/pyshark/capture/live_capture.py
+++ b/src/pyshark/capture/live_capture.py
@@ -74,6 +74,8 @@ class LiveCapture(Capture):
         all_interfaces_names = tshark.get_all_tshark_interfaces_names(self.tshark_path)
         all_interfaces_lowercase = [interface.lower() for interface in all_interfaces_names]
         for each_interface in self.interfaces:
+            if each_interface.startswith("rpcap://"):
+                continue
             if each_interface.isnumeric():
                 continue
             if each_interface.lower() not in all_interfaces_lowercase:


### PR DESCRIPTION
When creating a `RemoteCapture` as
```python 
capture = pyshark.RemoteCapture( '192.168.1.134', remote_interface='en0')
```
The init fails raising an `UnknownInterfaceException` from what I can tell this is simply because `LiveCapture._verify_capture_parameters` do not whitelist rpcap.