### PR TITLE
Add args and kwargs to RemoteCapture __init__

### DIFF
--- a/src/pyshark/capture/remote_capture.py
+++ b/src/pyshark/capture/remote_capture.py
@@ -4,14 +4,33 @@ from pyshark import LiveCapture
 class RemoteCapture(LiveCapture):
     """A capture which is performed on a remote machine which has an rpcapd service running."""
 
-    def __init__(self, remote_host, remote_interface, remote_port=2002, bpf_filter=None, only_summaries=False,
-                 decryption_key=None, encryption_type='wpa-pwk', decode_as=None,
-                 disable_protocol=None,tshark_path=None, override_prefs=None, eventloop=None, debug=False):
+    def __init__(
+        self,
+        remote_host,
+        remote_interface,
+        *args,
+        remote_port=2002,
+        bpf_filter=None,
+        only_summaries=False,
+        decryption_key=None,
+        encryption_type="wpa-pwk",
+        decode_as=None,
+        disable_protocol=None,
+        tshark_path=None,
+        override_prefs=None,
+        eventloop=None,
+        debug=False,
+        **kwargs
+    ):
         """
         Creates a new remote capture which will connect to a remote machine which is running rpcapd. Use the sniff()
         method to get packets.
         Note: The remote machine should have rpcapd running in null authentication mode (-n). Be warned that the traffic
         is unencrypted!
+
+        Note:
+            *args and **kwargs are passed to LiveCature's __init__ method.
+
 
         :param remote_host: The remote host to capture on (IP or hostname). Should be running rpcapd.
         :param remote_interface: The remote interface on the remote machine to capture on. Note that on windows it is
@@ -29,9 +48,19 @@ class RemoteCapture(LiveCapture):
         :param override_prefs: A dictionary of tshark preferences to override, {PREFERENCE_NAME: PREFERENCE_VALUE, ...}.
         :param disable_protocol: Tells tshark to remove a dissector for a specifc protocol.
         """
-        interface = 'rpcap://%s:%d/%s' % (remote_host, remote_port, remote_interface)
-        super(RemoteCapture, self).__init__(interface, bpf_filter=bpf_filter, only_summaries=only_summaries,
-                                            decryption_key=decryption_key, encryption_type=encryption_type,
-                                            tshark_path=tshark_path, decode_as=decode_as,  disable_protocol=disable_protocol,
-                                            override_prefs=override_prefs, eventloop=eventloop,
-                                            debug=debug)
+        interface = "rpcap://%s:%d/%s" % (remote_host, remote_port, remote_interface)
+        super(RemoteCapture, self).__init__(
+            interface,
+            *args,
+            bpf_filter=bpf_filter,
+            only_summaries=only_summaries,
+            decryption_key=decryption_key,
+            encryption_type=encryption_type,
+            tshark_path=tshark_path,
+            decode_as=decode_as,
+            disable_protocol=disable_protocol,
+            override_prefs=override_prefs,
+            eventloop=eventloop,
+            debug=debug,
+            **kwargs
+        )


### PR DESCRIPTION
Add `*args` and `**kwargs` to `RemoteCapture` so that all of `LiveCapture`'s feature can be used (for example `use_json`).