### PR TITLE
Add fifo option to FileCapture

### DIFF
--- a/src/pyshark/capture/file_capture.py
+++ b/src/pyshark/capture/file_capture.py
@@ -45,8 +45,8 @@ class FileCapture(Capture):
         self.input_filepath = pathlib.Path(input_file)
         if not self.input_filepath.exists():
             raise FileNotFoundError(f"[Errno 2] No such file or directory: {self.input_filepath}")
-        if not self.input_filepath.is_file():
-            raise FileNotFoundError(f"{self.input_filepath} is a directory")
+        if not self.input_filepath.is_file() and not self.input_filepath.is_fifo():
+            raise FileNotFoundError(f"{self.input_filepath} is not a file or fifo")
 
         self.keep_packets = keep_packets
         self._packet_generator = self._packets_from_tshark_sync()

--- a/src/pyshark/capture/live_capture.py
+++ b/src/pyshark/capture/live_capture.py
@@ -65,15 +65,19 @@ class LiveCapture(Capture):
 
     def get_parameters(self, packet_count=None):
         """Returns the special tshark parameters to be used according to the configuration of this class."""
-        params = super(LiveCapture, self).get_parameters(packet_count=packet_count)
-        # Read from STDIN
-        params += ["-i", "-"]
+        params = super(LiveCapture, self).get_parameters(
+            packet_count=packet_count)
+        # Read directly from interfaces
+        for interface in self.interfaces:
+            params += ["-i", interface]
         return params
 
     def _verify_capture_parameters(self):
         all_interfaces_names = tshark.get_all_tshark_interfaces_names(self.tshark_path)
         all_interfaces_lowercase = [interface.lower() for interface in all_interfaces_names]
         for each_interface in self.interfaces:
+            if each_interface.startswith("rpcap://"):
+                continue
             if each_interface.isnumeric():
                 continue
             if each_interface.lower() not in all_interfaces_lowercase:

--- a/src/pyshark/capture/pipe_capture.py
+++ b/src/pyshark/capture/pipe_capture.py
@@ -4,7 +4,7 @@ from pyshark.capture.capture import Capture
 
 
 class PipeCapture(Capture):
-    def __init__(self, pipe, display_filter=None, only_summaries=False,
+    def __init__(self, pipe, bpf_filter=None, display_filter=None, only_summaries=False,
                  decryption_key=None, encryption_type='wpa-pwk', decode_as=None,
                  disable_protocol=None, tshark_path=None, override_prefs=None, use_json=False,
                  include_raw=False, eventloop=None, custom_parameters=None, debug=False):
@@ -33,6 +33,7 @@ class PipeCapture(Capture):
                                           tshark_path=tshark_path, override_prefs=override_prefs,
                                           use_json=use_json, include_raw=include_raw, eventloop=eventloop,
                                           custom_parameters=custom_parameters, debug=debug)
+        self.bpf_filter = bpf_filter
         self._pipe = pipe
 
     def get_parameters(self, packet_count=None):

--- a/src/pyshark/capture/pipe_capture.py
+++ b/src/pyshark/capture/pipe_capture.py
@@ -4,7 +4,7 @@ from pyshark.capture.capture import Capture
 
 
 class PipeCapture(Capture):
-    def __init__(self, pipe, bpf_filter=None, display_filter=None, only_summaries=False,
+    def __init__(self, pipe, display_filter=None, only_summaries=False,
                  decryption_key=None, encryption_type='wpa-pwk', decode_as=None,
                  disable_protocol=None, tshark_path=None, override_prefs=None, use_json=False,
                  include_raw=False, eventloop=None, custom_parameters=None, debug=False):
@@ -33,7 +33,6 @@ class PipeCapture(Capture):
                                           tshark_path=tshark_path, override_prefs=override_prefs,
                                           use_json=use_json, include_raw=include_raw, eventloop=eventloop,
                                           custom_parameters=custom_parameters, debug=debug)
-        self.bpf_filter = bpf_filter
         self._pipe = pipe
 
     def get_parameters(self, packet_count=None):

--- a/src/pyshark/packet/packet.py
+++ b/src/pyshark/packet/packet.py
@@ -120,7 +120,7 @@ class Packet(Pickleable):
         Allows layers to be retrieved via get attr. For instance: pkt.ip
         """
         for layer in self.layers:
-            if layer.layer_name == item:
+            if layer.layer_name.lower() == item:
                 return layer
         raise AttributeError("No attribute named %s" % item)
 


### PR DESCRIPTION
This allows FileCapture to read from a FIFO, which can be useful for parsing the kismet pcapng stream.

```
mkfifo /tmp/sharkfin || true
wireshark -k -i /tmp/sharkfin &
curl -N -u user:password http://localhost:2501/pcap/all_packets.pcapng > /tmp/sharkfin &
```