### PR TITLE
unicode support added to correct issue617

### DIFF
--- a/src/pyshark/tshark/output_parser/tshark_xml.py
+++ b/src/pyshark/tshark/output_parser/tshark_xml.py
@@ -77,9 +77,9 @@ def packet_from_xml_packet(xml_pkt, psml_structure=None):
     :return: Packet object.
     """
     if not isinstance(xml_pkt, lxml.objectify.ObjectifiedElement):
-        parser = lxml.objectify.makeparser(huge_tree=True, recover=True)
+        parser = lxml.objectify.makeparser(huge_tree=True, recover=True, encoding='utf-8')
         xml_pkt = xml_pkt.decode(errors='ignore').translate(DEL_BAD_XML_CHARS)
-        xml_pkt = lxml.objectify.fromstring(xml_pkt, parser)
+        xml_pkt = lxml.objectify.fromstring(xml_pkt.encode('utf-8'), parser)
     if psml_structure:
         return _packet_from_psml_packet(xml_pkt, psml_structure)
     return _packet_from_pdml_packet(xml_pkt)


### PR DESCRIPTION
This is the two line patch to handle issue #617. The changes allow for a unicode string to be handled by `lxml.objectify.fromstring()` without it returning `None`, as it does presently. 

This bug can be easily reproduced by running the `bpf_filter` string `udp port 5353` and then add a emoji to your device name (like an iPhone). This causes MDNS packets (i.e. port 5353) to contain an unicode string.

The code change seems to cleanly fix this issue and doesn't affect existing xml packet strings.