### PR TITLE
stderr closing now triggers end of file processing - added to correct issue623

### DIFF
--- a/src/pyshark/capture/capture.py
+++ b/src/pyshark/capture/capture.py
@@ -216,7 +216,7 @@ class Capture:
 
         data = b""
         try:
-            while True:
+            while not self._eof_reached:
                 try:
                     packet, data = self.eventloop.run_until_complete(
                         parser.get_packets_from_stream(tshark_process.stdout, data,
@@ -279,7 +279,7 @@ class Capture:
         parser = self._setup_tshark_output_parser()
         data = b""
 
-        while True:
+        while not self._eof_reached:
             try:
                 packet, data = await parser.get_packets_from_stream(fd, data,
                                                                     got_first_packet=packets_captured > 0)
@@ -306,6 +306,9 @@ class Capture:
         while True:
             stderr_line = await stderr.readline()
             if not stderr_line:
+                self._log.debug("EOF on subprocesss - something died")
+                self._eof_reached = True
+                await self.close_async()
                 break
             stderr_line = stderr_line.decode().strip()
             self._last_error_line = stderr_line


### PR DESCRIPTION
PR for issue #623.

Code added to trigger `self._eof_reached` set to `True` once `stderr` from a subprocess shows eof. This happens when the capture subprocess hits an error (for example, a bad filter string).

Reproduce by simply setting `bpf_filter` to anything invalid.

Tested on MacBook Air running `BigSur 11.7.1`.