### PR TITLE
Make packet layer names case-insensitive for backward compatibility with v0.4.6

### DIFF
--- a/src/pyshark/packet/packet.py
+++ b/src/pyshark/packet/packet.py
@@ -47,7 +47,7 @@ class Packet(Pickleable):
         if isinstance(item, int):
             return self.layers[item]
         for layer in self.layers:
-            if layer.layer_name == item.lower():
+            if layer.layer_name.lower() == item.lower():
                 return layer
         raise KeyError('Layer does not exist in packet')
 
@@ -120,7 +120,7 @@ class Packet(Pickleable):
         Allows layers to be retrieved via get attr. For instance: pkt.ip
         """
         for layer in self.layers:
-            if layer.layer_name == item:
+            if layer.layer_name.lower() == item.lower():
                 return layer
         raise AttributeError(f"No attribute named {item}")
 


### PR DESCRIPTION
pyshark v0.5 broke backward compatibility with v0.4.6 by renaming the packet `data` layer to `DATA`. (See issue #637.) This PR makes packet layer names case-insensitive to retain backward and forward compatibility with both names.