### PR TITLE
fix live_ring_capture.py

### DIFF
--- a/src/pyshark/capture/live_ring_capture.py
+++ b/src/pyshark/capture/live_ring_capture.py
@@ -50,3 +50,8 @@ class LiveRingCapture(LiveCapture):
         params += ['-b', 'filesize:' + str(self.ring_file_size), '-b', 'files:' + str(self.num_ring_files),
                    '-w', self.ring_file_name, '-P', '-V']
         return params
+    
+    def _get_dumpcap_parameters(self):
+        params = super(LiveRingCapture, self)._get_dumpcap_parameters()
+        params += ['-P']
+        return params


### PR DESCRIPTION
this fixes #633 

changes dumpcap output file to the pcap format which can be read by tshark's `-i`

