### PR TITLE
fix/json_pretty_print

### DIFF
--- a/src/pyshark/packet/layers/json_layer.py
+++ b/src/pyshark/packet/layers/json_layer.py
@@ -83,7 +83,7 @@ class JsonLayer(BaseLayer):
         for field_line in self._get_all_field_lines():
             if ':' in field_line:
                 field_name, field_line = field_line.split(':', 1)
-                file.write(colored(field_name + ':', "green", ["bold"]))
+                file.write(colored(field_name + ':', "green", attrs=["bold"]))
             file.write(colored(field_line, attrs=["bold"]))
 
     def _get_all_field_lines(self):


### PR DESCRIPTION
Fixes an issue where `json_layer.py` using positional argument instead of keyword argument.

Function definition from `termcolor.py`:
```
def colored(
    text: str,
    color: str | None = None,
    on_color: str | None = None,
    attrs: Iterable[str] | None = None,
    *,
    no_color: bool | None = None,
    force_color: bool | None = None,
) 
```