### PR TITLE
capture: Fix close_async in case the stderr task is still running

### DIFF
--- a/src/pyshark/capture/capture.py
+++ b/src/pyshark/capture/capture.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import os
 import threading
 import subprocess
@@ -398,7 +399,10 @@ class Capture:
         self._running_processes.clear()
 
         # Wait for all stderr handling to finish
-        await asyncio.gather(*self._stderr_handling_tasks)
+        for task in self._stderr_handling_tasks:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
 
     def __del__(self):
         if self._running_processes:


### PR DESCRIPTION
In some cases (happens often inside dockers), the stderr handling task doesn't close by itself, so cancelling is required