### PR TITLE
Add "length" property to FileCapture without user needs to explicit iterate over the capture

### DIFF
--- a/tests/capture/test_capture.py
+++ b/tests/capture/test_capture.py
@@ -70,3 +70,9 @@ def test_capture_gets_encryption_and_override_perfs():
         assert set(actual_parameter_options) == set(expected_results)
         assert len(actual_parameter_options) == len(expected_results)
 
+def test_get_length_from_file_capture():
+    cap = FileCapture("../data/capture_test.pcapng")
+    length_without_iterating = len(cap)
+    counter = 0
+    length_with_iterating = len([_ for _ in cap])
+    assert length_with_iterating == length_without_iterating


### PR DESCRIPTION
This pull request aims to enhance the FileCapture class by introducing a 'length' property. With this addition, users will no longer need to explicitly iterate over the capture to determine its size. This improvement streamlines the interaction with FileCapture instances, providing a more convenient and efficient way to access the number of captured items.