### PR TITLE
Added type hints to LayerFieldsContainer class for consistency

### DIFF
--- a/src/pyshark/packet/fields.py
+++ b/src/pyshark/packet/fields.py
@@ -94,20 +94,20 @@ class LayerFieldsContainer(str, Pickleable):
     def __dir__(self):
         return dir(type(self)) + list(self.__dict__.keys()) + dir(self.main_field)
 
-    def add_field(self, field):
+    def add_field(self, field) -> None:
         self.fields.append(field)
 
     @property
-    def all_fields(self):
+    def all_fields(self) -> list:
         """Returns all fields in a list, the main field followed by the alternate fields."""
         return self.fields
 
     @property
-    def main_field(self):
+    def main_field(self) -> LayerField:
         return self.fields[0]
 
     @property
-    def alternate_fields(self):
+    def alternate_fields(self) -> list:
         """Return the alternate values of this field containers (non-main ones)."""
         return self.fields[1:]
 


### PR DESCRIPTION
Added type hints to the non-private methods of the LayerFieldsContainer class to bring in line with LayerField class' type-hinting. Closes issue #714.