### PR TITLE
Added two options to avoid using excessive memory

### DIFF
--- a/src/pyshark/capture/live_capture.py
+++ b/src/pyshark/capture/live_capture.py
@@ -21,7 +21,7 @@ class LiveCapture(Capture):
                  disable_protocol=None, tshark_path=None, override_prefs=None, capture_filter=None,
                  monitor_mode=False, use_json=False, use_ek=False,
                  include_raw=False, eventloop=None, custom_parameters=None,
-                 debug=False):
+                 debug=False, store_packets=True, disable_dissection=False):
         """Creates a new live capturer on a given interface. Does not start the actual capture itself.
 
         :param interface: Name of the interface to sniff on or a list of names (str). If not given, runs on all interfaces.
@@ -43,6 +43,8 @@ class LiveCapture(Capture):
         :param use_json: DEPRECATED. Use use_ek instead.
         :param custom_parameters: A dict of custom parameters to pass to tshark, i.e. {"--param": "value"} or
         else a list of parameters in the format ["--foo", "bar", "--baz", "foo"].
+        :param store_packets: Tells the parent class whether we want the packets to be stored in memory or not.
+        :param disable_dissection: Tells T-Shark to disable all protocol dissectors to save memory.
         """
         super(LiveCapture, self).__init__(display_filter=display_filter, only_summaries=only_summaries,
                                           decryption_key=decryption_key, encryption_type=encryption_type,
@@ -51,7 +53,7 @@ class LiveCapture(Capture):
                                           capture_filter=capture_filter, use_json=use_json, use_ek=use_ek,
                                           include_raw=include_raw,
                                           eventloop=eventloop, custom_parameters=custom_parameters,
-                                          debug=debug)
+                                          debug=debug, store_packets=store_packets, disable_dissection=disable_dissection)
         self.bpf_filter = bpf_filter
         self.monitor_mode = monitor_mode
 

--- a/src/pyshark/capture/live_ring_capture.py
+++ b/src/pyshark/capture/live_ring_capture.py
@@ -9,7 +9,7 @@ class LiveRingCapture(LiveCapture):
                  encryption_type='wpa-pwk', decode_as=None, disable_protocol=None,
                  tshark_path=None, override_prefs=None, capture_filter=None, 
                  use_json=False, use_ek=False, include_raw=False, eventloop=None, 
-                 custom_parameters=None, debug=False):
+                 custom_parameters=None, debug=False, store_packets=True, disable_dissection=False):
         """
         Creates a new live capturer on a given interface. Does not start the actual capture itself.
         :param ring_file_size: Size of the ring file in kB, default is 1024
@@ -28,18 +28,20 @@ class LiveRingCapture(LiveCapture):
         :param tshark_path: Path of the tshark binary
         :param override_prefs: A dictionary of tshark preferences to override, {PREFERENCE_NAME: PREFERENCE_VALUE, ...}.
         :param capture_filter: Capture (wireshark) filter to use.
-        :param disable_protocol: Tells tshark to remove a dissector for a specifc protocol.
+        :param disable_protocol: Tells tshark to remove a dissector for a specific protocol.
         :param use_ek: Uses tshark in EK JSON mode. It is faster than XML but has slightly less data.
         :param use_json: DEPRECATED. Use use_ek instead.
         :param custom_parameters:  A dict of custom parameters to pass to tshark, i.e. {"--param": "value"}
         or else a list of parameters in the format ["--foo", "bar", "--baz", "foo"]. or else a list of parameters in the format ["--foo", "bar", "--baz", "foo"].
+        :param store_packets: Tells the parent class whether we want the packets to be stored in memory or not.
+        :param disable_dissection: Tells T-Shark to disable all protocol dissectors to save memory.
         """
         super(LiveRingCapture, self).__init__(interface, bpf_filter=bpf_filter, display_filter=display_filter, only_summaries=only_summaries,
                                               decryption_key=decryption_key, encryption_type=encryption_type,
                                               tshark_path=tshark_path, decode_as=decode_as, disable_protocol=disable_protocol,
                                               override_prefs=override_prefs, capture_filter=capture_filter, 
                                               use_json=use_json, use_ek=use_ek, include_raw=include_raw, eventloop=eventloop,
-                                              custom_parameters=custom_parameters, debug=debug)
+                                              custom_parameters=custom_parameters, debug=debug, store_packet=store_packets, disable_dissection=disable_dissection)
 
         self.ring_file_size = ring_file_size
         self.num_ring_files = num_ring_files


### PR DESCRIPTION
Hello,

I'm using PyShark to manage T-Shark workers that capture packets 24/7 in the background. I only need the packets to be written to a file, and therefore, I don't need the packets in memory and I don't need T-Shark to dissect everything. When I use PyShark this way, I encounter two problems:

1) PyShark keeps packets in memory and that is consuming a lot of memory. OOM comes by and kills it within a couple of hours.
2) T-Shark uses excessive CPU and memory because it tries to dissect everything.

Therefore I made some changes to the code and I want to propose them to be merged for everybody to use. I introduced two options:

1) `store_packets` which can be set to `False` to avoid packets to be kept in the internal list;
2) `disable_dissection` which can be set to `True` to pass the `--disable-all-protocols` switch to T-Shark.

This works for me, as memory and CPU usage is down by so much that it is feasible. Implemented the options in the LiveRingCapture class too, but did not test it.

I apologize for the CRLF endings that the Windows Git might have put on.