### PR TITLE
Replace deprecated appdirs with platformdirs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Development requirements. Only required for testing
-appdirs
+platformdirs
 py
 pytest
 lxml

--- a/src/pyshark/cache.py
+++ b/src/pyshark/cache.py
@@ -1,11 +1,11 @@
 import pathlib
 import shutil
 
-import appdirs
+import platformdirs
 
 
 def get_cache_dir(tshark_version) -> pathlib.Path:
-    cache_dir = pathlib.Path(appdirs.user_cache_dir(appname="pyshark", version=tshark_version))
+    cache_dir = pathlib.Path(platformdirs.user_cache_dir(appname="pyshark", version=tshark_version))
     if not cache_dir.exists():
         cache_dir.mkdir(parents=True)
     return cache_dir

--- a/src/setup.py
+++ b/src/setup.py
@@ -9,7 +9,7 @@ setup(
     version="0.6.1",
     packages=find_packages(),
     package_data={'': ['*.ini', '*.pcapng']},
-    install_requires=['lxml', 'termcolor', 'packaging', 'appdirs'],
+    install_requires=['lxml', 'termcolor', 'packaging', 'platformdirs'],
     tests_require=['pytest'],
     url="https://github.com/KimiNewt/pyshark",
     license="MIT",


### PR DESCRIPTION

Hello

The module appdirs has been officially deprecated by upstream and has now been removed from Debian too.
It should be replaced with the current active fork platformdirs:

https://github.com/ActiveState/appdirs
https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1060427

Thanks
