### PR TITLE
fix: support ISO 8601 timestamp format in Packet.sniff_time for tshark 4.6+ JSON/EK output

### DIFF
--- a/src/pyshark/packet/packet.py
+++ b/src/pyshark/packet/packet.py
@@ -83,6 +83,8 @@ class Packet(Pickleable):
 
     @property
     def sniff_time(self) -> datetime.datetime:
+        if self.sniff_timestamp[-1] == 'Z':
+            return datetime.datetime.fromisoformat(self.sniff_timestamp)
         try:
             timestamp = float(self.sniff_timestamp)
         except ValueError:


### PR DESCRIPTION
**Summary**

tshark 4.6.0 changed the JSON/EK output format of frame.time_epoch from a float-based Unix timestamp to an ISO 8601 string (e.g. 2025-10-22T02:20:33.634243780Z).
This caused ValueError: could not convert string to float when parsing packets with PyShark.

[https://www.wireshark.org/docs/relnotes/wireshark-4.6.0](url)

> Absolute time fields, regardless of field display in the Packet Details, are always written in ISO 8601 format in UTC with -T json. This was already the case for -T ek since version 4.2.0. JSON is primarily a data interchange format read by software, so a standard format is desirable.

**Fix**

Updated Packet.sniff_time to detect ISO 8601 timestamps (ending with Z) and parse them using datetime.fromisoformat().
The old float-based parsing is kept for backward compatibility.

**Compatibility**

- Works with both tshark ≤4.4 (float) and 4.6+ (ISO 8601)

- No external dependencies added


Fixes #718
