### PR TITLE
Fix tests on openSUSE-Tumbleweed

### DIFF
--- a/src/pyshark/tshark/tshark.py
+++ b/src/pyshark/tshark/tshark.py
@@ -143,7 +143,7 @@ def get_ek_field_mapping(tshark_path=None):
         mapping,
         object_pairs_hook=_duplicate_object_hook)["mappings"]
     # If using wireshark 4, the key "mapping" contains what we want,
-    if "dynamic" in mapping and "properties" in mapping:
+    if "properties" in mapping:
         pass
     # if using wireshark 3.5 to < 4 the data in "mapping.doc",
     elif "doc" in mapping:


### PR DESCRIPTION
For some reason, `tshark -G elastic-mapping`
had no `"dynamic"` element.

This might not be the correct fix, so review / test carefully.