### PR TITLE
Version compatibility update

### DIFF
--- a/src/pyshark/capture/capture.py
+++ b/src/pyshark/capture/capture.py
@@ -168,6 +168,14 @@ class Capture:
 
     def _setup_eventloop(self):
         """Sets up a new eventloop as the current one according to the OS."""
+        if sys.version_info >= (3, 14):
+            try:
+                self.eventloop = asyncio.get_event_loop()
+            except RuntimeError:
+                self.eventloop = asyncio.new_event_loop()
+                asyncio.set_event_loop(self.eventloop)
+            return
+
         if os.name == "nt":
             current_eventloop = asyncio.get_event_loop_policy().get_event_loop()
             if isinstance(current_eventloop, asyncio.ProactorEventLoop):

--- a/tests/test_cap_operations.py
+++ b/tests/test_cap_operations.py
@@ -7,7 +7,9 @@ from unittest import mock
 
 import pytest
 
+import pyshark
 from pyshark.packet.packet_summary import PacketSummary
+from tests.conftest import example_pcap_path
 
 
 def test_packet_callback_called_for_each_packet(lazy_simple_capture):
@@ -60,17 +62,18 @@ def test_getting_packet_summary(simple_summary_capture):
     assert simple_summary_capture[0]._fields
 
 
-def _iterate_capture_object(cap_obj, q):
+def _iterate_capture_object(example_pcap_path, q):
+    cap_obj = pyshark.FileCapture(example_pcap_path, debug=True, only_summaries=True)
+    cap_obj.display_filter = "frame.len == 1"
     for _ in cap_obj:
         pass
     q.put(True)
 
 
-def test_iterate_empty_psml_capture(simple_summary_capture):
-    simple_summary_capture.display_filter = "frame.len == 1"
+def test_iterate_empty_psml_capture(example_pcap_path):
     q = Queue()
     p = Process(target=_iterate_capture_object,
-                args=(simple_summary_capture, q))
+                args=(example_pcap_path, q))
     p.start()
     p.join(2)
     try:


### PR DESCRIPTION
Most recent Python versions removed parts of the API used in capture.py. This patch restores compatibility.

For more recent Python versions, this patch removes usage of the removed ChildWatcher APIs (and of the deprecated Policies) and simply retrieves or creates the event loop in the recommended way.

As far as I can tell, there is not gap in functionality: Using a SafeChildWatcher instead of ThreadedChildWatcher on Unix systems suppressed an error message about already awaited children, but did not resolve the underlying issue (calling wait on the same PID multiple times), which is moreover an uncritical condition (as noted in the commit that introduced SafeChildWatcher as a workaround). In any case: The redundant wait seems to be due to code that awaits the child manually via `communicate()`  or similar. This is not a bug and IMO it's a bit odd that this causes a warning.

In most recent versions of the Python asyncio APIs, it is no longer possible to change the ChildWatcher in this fashion anyways, and API version 3.14 no longer has a SafeChildWatcher, not even internally.

The tests did not show any regressions, but one test failed due to a picking issue (logger cannot be picked). That test did not fail with `master` and  Python 3.12, but now fails for some reason. I do not believe this is related to this patch, though. Nevertheless, I fixed that test by avoiding the picking operation. All tests now pass.